### PR TITLE
Add i18n support with English and Japanese

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,8 @@
       "WebSearch",
       "Bash(pod install:*)",
       "Bash(npx expo-modules-autolinking:*)",
+      "WebFetch(domain:react.i18next.com)",
+      "WebFetch(domain:www.i18next.com)",
       "Bash(./gradlew *)",
       "Bash(python3 -m json.tool)"
     ]

--- a/app.json
+++ b/app.json
@@ -13,6 +13,7 @@
       "backgroundColor": "#ffffff"
     },
     "locales": {
+      "en": "./languages/en.json",
       "ja": "./languages/ja.json"
     },
     "ios": {

--- a/app.json
+++ b/app.json
@@ -12,11 +12,17 @@
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
+    "locales": {
+      "ja": "./languages/ja.json"
+    },
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "net.tai2.voicemirror",
       "config": {
         "usesNonExemptEncryption": false
+      },
+      "infoPlist": {
+        "CFBundleAllowMixedLocalizations": true
       }
     },
     "android": {
@@ -44,6 +50,12 @@
         {
           "iosMicrophonePermission": "VoiceMirror records your voice so you can immediately hear yourself back.",
           "androidPermissions": ["android.permission.RECORD_AUDIO"]
+        }
+      ],
+      [
+        "expo-localization",
+        {
+          "supportedLocales": ["en", "ja"]
         }
       ]
     ]

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,8 @@ import { View, Text, StyleSheet, StatusBar as RNStatusBar } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { Stack } from "expo-router";
 import { useSyncExternalStore } from "react";
+import { I18nProvider } from "../src/context/I18nProvider";
+import { useTranslation } from "react-i18next";
 import { ServicesProvider } from "../src/context/ServicesProvider";
 import { SettingsProvider } from "../src/context/SettingsProvider";
 import { RealAudioRecordingService } from "../src/services/AudioRecordingService";
@@ -77,25 +79,34 @@ function E2EBanner() {
   );
 }
 
+function RootStack() {
+  const { t } = useTranslation();
+  return (
+    <Stack>
+      <Stack.Screen
+        name="index"
+        options={{ title: "VoiceMirror", headerShown: false }}
+      />
+      <Stack.Screen
+        name="settings"
+        options={{ title: t("settings.title"), presentation: "card" }}
+      />
+    </Stack>
+  );
+}
+
 export default function RootLayout() {
   return (
     <GestureHandlerRootView style={styles.root}>
-      <ServicesProvider services={isE2E ? e2eServices : realServices}>
-        <SettingsProvider repository={settingsRepository}>
-          <Stack>
-            <Stack.Screen
-              name="index"
-              options={{ title: "VoiceMirror", headerShown: false }}
-            />
-            <Stack.Screen
-              name="settings"
-              options={{ title: "Settings", presentation: "card" }}
-            />
-          </Stack>
-          {isE2E && <E2EBanner />}
-          <StatusBar style="dark" />
-        </SettingsProvider>
-      </ServicesProvider>
+      <I18nProvider>
+        <ServicesProvider services={isE2E ? e2eServices : realServices}>
+          <SettingsProvider repository={settingsRepository}>
+            <RootStack />
+            {isE2E && <E2EBanner />}
+            <StatusBar style="dark" />
+          </SettingsProvider>
+        </ServicesProvider>
+      </I18nProvider>
     </GestureHandlerRootView>
   );
 }

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,13 +1,14 @@
 import { View, Text, StyleSheet, ScrollView, SafeAreaView } from "react-native";
 import Slider from "@react-native-community/slider";
+import { useTranslation } from "react-i18next";
 import { useSettings } from "../src/context/SettingsProvider";
 import type { DetectionSettings } from "../src/types/settings";
 import { DEFAULT_SETTINGS } from "../src/types/settings";
 
 type SliderConfig = {
   key: keyof DetectionSettings;
-  label: string;
-  description: string;
+  labelKey: string;
+  descriptionKey: string;
   min: number;
   max: number;
   step: number;
@@ -17,9 +18,8 @@ type SliderConfig = {
 const SLIDERS: SliderConfig[] = [
   {
     key: "voiceThresholdDb",
-    label: "Voice Threshold",
-    description:
-      "Audio level (in dB) that must be exceeded to begin voice onset detection. Lower values make detection more sensitive to quiet speech; higher values require louder input.",
+    labelKey: "settings.voice_threshold_label",
+    descriptionKey: "settings.voice_threshold_description",
     min: -60,
     max: -10,
     step: 1,
@@ -27,9 +27,8 @@ const SLIDERS: SliderConfig[] = [
   },
   {
     key: "voiceOnsetMs",
-    label: "Voice Onset Duration",
-    description:
-      "How long (in ms) the audio must stay above the voice threshold before recording starts. Shorter values react faster but may trigger on brief noises; longer values are more conservative.",
+    labelKey: "settings.voice_onset_label",
+    descriptionKey: "settings.voice_onset_description",
     min: 50,
     max: 1000,
     step: 50,
@@ -37,9 +36,8 @@ const SLIDERS: SliderConfig[] = [
   },
   {
     key: "silenceThresholdDb",
-    label: "Silence Threshold",
-    description:
-      "Audio level (in dB) below which silence detection begins. Should be lower than the voice threshold. Lower values tolerate more background noise before ending a recording.",
+    labelKey: "settings.silence_threshold_label",
+    descriptionKey: "settings.silence_threshold_description",
     min: -70,
     max: -10,
     step: 1,
@@ -47,9 +45,8 @@ const SLIDERS: SliderConfig[] = [
   },
   {
     key: "silenceDurationMs",
-    label: "Silence Duration",
-    description:
-      "How long (in ms) silence must persist before the recording ends. Longer values allow natural pauses in speech without cutting off; shorter values end recordings faster.",
+    labelKey: "settings.silence_duration_label",
+    descriptionKey: "settings.silence_duration_description",
     min: 300,
     max: 5000,
     step: 100,
@@ -57,9 +54,8 @@ const SLIDERS: SliderConfig[] = [
   },
   {
     key: "minRecordingMs",
-    label: "Min Recording Duration",
-    description:
-      "Minimum amount of speech (in ms) that must be captured before silence can end the recording. Prevents very short accidental recordings.",
+    labelKey: "settings.min_recording_label",
+    descriptionKey: "settings.min_recording_description",
     min: 100,
     max: 3000,
     step: 100,
@@ -68,18 +64,19 @@ const SLIDERS: SliderConfig[] = [
 ];
 
 function SettingSlider({ config }: { config: SliderConfig }) {
+  const { t } = useTranslation();
   const { settings, updateSetting } = useSettings();
   const value = settings[config.key];
 
   return (
     <View style={styles.sliderCard}>
       <View style={styles.sliderHeader}>
-        <Text style={styles.sliderLabel}>{config.label}</Text>
+        <Text style={styles.sliderLabel}>{t(config.labelKey)}</Text>
         <Text style={styles.sliderValue}>
           {value} {config.unit}
         </Text>
       </View>
-      <Text style={styles.sliderDescription}>{config.description}</Text>
+      <Text style={styles.sliderDescription}>{t(config.descriptionKey)}</Text>
       <Slider
         minimumValue={config.min}
         maximumValue={config.max}
@@ -94,7 +91,7 @@ function SettingSlider({ config }: { config: SliderConfig }) {
           {config.min} {config.unit}
         </Text>
         <Text style={styles.defaultLabel}>
-          default: {DEFAULT_SETTINGS[config.key]} {config.unit}
+          {t("settings.default_prefix")} {DEFAULT_SETTINGS[config.key]} {config.unit}
         </Text>
         <Text style={styles.rangeLabel}>
           {config.max} {config.unit}

--- a/languages/en.json
+++ b/languages/en.json
@@ -1,0 +1,5 @@
+{
+  "ios": {
+    "NSMicrophoneUsageDescription": "VoiceMirror records your voice so you can immediately hear yourself back."
+  }
+}

--- a/languages/ja.json
+++ b/languages/ja.json
@@ -1,0 +1,5 @@
+{
+  "ios": {
+    "NSMicrophoneUsageDescription": "VoiceMirrorがあなたの声を録音し、すぐに再生します。"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -33,9 +33,12 @@
     "expo": "~55.0.5",
     "expo-dev-client": "^55.0.11",
     "expo-file-system": "^55.0.11",
+    "expo-localization": "^55.0.9",
     "expo-router": "^55.0.7",
     "expo-status-bar": "~55.0.4",
+    "i18next": "^25.10.10",
     "react": "19.2.0",
+    "react-i18next": "^16.6.6",
     "react-native": "0.83.2",
     "react-native-audio-api": "^0.11.7",
     "react-native-gesture-handler": "~2.30.0"

--- a/plans/20260327-add-i18n.md
+++ b/plans/20260327-add-i18n.md
@@ -1,0 +1,757 @@
+# Internationalization (i18n) — Implementation Plan
+
+## Goal
+
+Add English and Japanese language support to VoiceMirror using `react-i18next`, with automatic language detection from the device locale. Enable iOS and Android "Per-App Language Selection" so users can choose the app language independently of their device language via system settings, without any custom in-app language picker.
+
+## Architecture
+
+### Overview
+
+```
+Device locale (expo-localization getLocales())
+    |
+    v
+src/i18n/index.ts  (i18next init, resources, lng selection)
+    |
+    v
+app/_layout.tsx  (I18nextProvider wraps the app)
+    |
+    +--> useTranslation() in every component with user-facing text
+    |      t('key') resolves from bundled JSON resources
+    |
+    +--> Per-App Language Selection (OS-level)
+           iOS: CFBundleAllowMixedLocalizations + locales in app.json
+           Android: locales in app.json + expo-localization plugin
+```
+
+### Key decisions
+
+1. **Bundled resources, not lazy-loaded.** The app has ~30-35 strings. JSON translation files are imported directly in the i18n init module. No HTTP backend needed.
+
+2. **Single namespace.** With only ~35 strings, multiple namespaces add complexity without benefit. All translations live under the default `translation` namespace.
+
+3. **Flat key structure with dot-separated sections.** Keys are organized as `section.key` (e.g. `main.hint_listening`, `settings.voice_threshold_label`) for readability, but remain in a single flat JSON file per language.
+
+4. **Error codes instead of translated strings in hooks.** The `useVoiceMirror` hook currently sets `recordingError` to a hardcoded 
+English string. This will change to return an error key (e.g. `"recording_failed"`), and the component will translate it via `t()`. This aligns with the project's dependency injection pattern -- hooks remain translation-agnostic.
+
+5. **Per-App Language Selection via expo-localization plugin.** The `expo-localization` Expo config plugin with `supportedLocales: ["en", "ja"]` writes the necessary native configuration (`CFBundleDevelopmentRegion`, `CFBundleLocalizations` on iOS; locale resource dirs on Android) so that the OS surfaces a per-app language picker in system settings.
+
+6. **Listening for locale changes.** Using `useLocales()` from `expo-localization` ensures the app re-renders when the user changes the per-app language while the app is running. The `I18nProvider` component will sync `i18n.language` with the device/per-app locale.
+
+## Dependencies
+
+```bash
+pnpm add i18next react-i18next expo-localization
+```
+
+No additional dev dependencies required.
+
+## File Structure
+
+```
+src/
+  i18n/
+    index.ts                    # i18next initialization
+    locales/
+      en/
+        translation.json        # English translations
+      ja/
+        translation.json        # Japanese translations
+  context/
+    I18nProvider.tsx             # Locale-change listener, I18nextProvider wrapper
+languages/
+  ja.json                       # Native-level localized strings (NSMicrophoneUsageDescription)
+```
+
+## Detailed Changes
+
+### 1. Translation files
+
+#### `src/i18n/locales/en/translation.json`
+
+```json
+{
+  "main.error_title": "Microphone access required",
+  "main.error_body": "Go to Settings \u2192 VoiceMirror \u2192 Microphone and allow access.",
+  "main.hint_requesting": "Requesting microphone access\u2026",
+  "main.hint_paused": "Monitoring paused.",
+  "main.hint_listening": "Speak to begin. Silence ends the take.",
+  "main.button_resume": "Resume",
+  "main.button_pause": "Pause",
+  "main.recording_failed": "Recording failed to save.",
+
+  "phase.idle": "Listening\u2026",
+  "phase.recording": "Recording",
+  "phase.playing": "Playing back",
+  "phase.paused": "Paused",
+
+  "recordings.empty": "No recordings yet",
+  "recordings.delete": "Delete",
+
+  "settings.title": "Settings",
+  "settings.voice_threshold_label": "Voice Threshold",
+  "settings.voice_threshold_description": "Audio level (in dB) that must be exceeded to begin voice onset detection. Lower values make detection more sensitive to quiet speech; higher values require louder input.",
+  "settings.voice_onset_label": "Voice Onset Duration",
+  "settings.voice_onset_description": "How long (in ms) the audio must stay above the voice threshold before recording starts. Shorter values react faster but may trigger on brief noises; longer values are more conservative.",
+  "settings.silence_threshold_label": "Silence Threshold",
+  "settings.silence_threshold_description": "Audio level (in dB) below which silence detection begins. Should be lower than the voice threshold. Lower values tolerate more background noise before ending a recording.",
+  "settings.silence_duration_label": "Silence Duration",
+  "settings.silence_duration_description": "How long (in ms) silence must persist before the recording ends. Longer values allow natural pauses in speech without cutting off; shorter values end recordings faster.",
+  "settings.min_recording_label": "Min Recording Duration",
+  "settings.min_recording_description": "Minimum amount of speech (in ms) that must be captured before silence can end the recording. Prevents very short accidental recordings.",
+  "settings.default_prefix": "default:"
+}
+```
+
+#### `src/i18n/locales/ja/translation.json`
+
+```json
+{
+  "main.error_title": "\u30de\u30a4\u30af\u3078\u306e\u30a2\u30af\u30bb\u30b9\u304c\u5fc5\u8981\u3067\u3059",
+  "main.error_body": "\u8a2d\u5b9a \u2192 VoiceMirror \u2192 \u30de\u30a4\u30af\u304b\u3089\u30a2\u30af\u30bb\u30b9\u3092\u8a31\u53ef\u3057\u3066\u304f\u3060\u3055\u3044\u3002",
+  "main.hint_requesting": "\u30de\u30a4\u30af\u3078\u306e\u30a2\u30af\u30bb\u30b9\u3092\u30ea\u30af\u30a8\u30b9\u30c8\u4e2d\u2026",
+  "main.hint_paused": "\u30e2\u30cb\u30bf\u30ea\u30f3\u30b0\u4e00\u6642\u505c\u6b62\u4e2d",
+  "main.hint_listening": "\u8a71\u3057\u304b\u3051\u3066\u304f\u3060\u3055\u3044\u3002\u6c88\u9ed9\u3067\u7d42\u4e86\u3057\u307e\u3059\u3002",
+  "main.button_resume": "\u518d\u958b",
+  "main.button_pause": "\u4e00\u6642\u505c\u6b62",
+  "main.recording_failed": "\u9332\u97f3\u306e\u4fdd\u5b58\u306b\u5931\u6557\u3057\u307e\u3057\u305f\u3002",
+
+  "phase.idle": "\u5f85\u6a5f\u4e2d\u2026",
+  "phase.recording": "\u9332\u97f3\u4e2d",
+  "phase.playing": "\u518d\u751f\u4e2d",
+  "phase.paused": "\u4e00\u6642\u505c\u6b62",
+
+  "recordings.empty": "\u9332\u97f3\u306f\u307e\u3060\u3042\u308a\u307e\u305b\u3093",
+  "recordings.delete": "\u524a\u9664",
+
+  "settings.title": "\u8a2d\u5b9a",
+  "settings.voice_threshold_label": "\u97f3\u58f0\u95be\u5024",
+  "settings.voice_threshold_description": "\u97f3\u58f0\u691c\u51fa\u3092\u958b\u59cb\u3059\u308b\u305f\u3081\u306b\u8d85\u3048\u308b\u5fc5\u8981\u304c\u3042\u308b\u97f3\u91cf\u30ec\u30d9\u30eb\uff08dB\uff09\u3002\u4f4e\u3044\u5024\u306f\u5c0f\u3055\u306a\u58f0\u306b\u654f\u611f\u306b\u306a\u308a\u3001\u9ad8\u3044\u5024\u306f\u3088\u308a\u5927\u304d\u306a\u5165\u529b\u3092\u5fc5\u8981\u3068\u3057\u307e\u3059\u3002",
+  "settings.voice_onset_label": "\u97f3\u58f0\u958b\u59cb\u6642\u9593",
+  "settings.voice_onset_description": "\u9332\u97f3\u304c\u958b\u59cb\u3055\u308c\u308b\u307e\u3067\u306b\u97f3\u58f0\u95be\u5024\u3092\u8d85\u3048\u7d9a\u3051\u308b\u5fc5\u8981\u304c\u3042\u308b\u6642\u9593\uff08ms\uff09\u3002\u77ed\u3044\u5024\u306f\u53cd\u5fdc\u304c\u65e9\u304f\u306a\u308a\u307e\u3059\u304c\u77ed\u3044\u96d1\u97f3\u3067\u8aa4\u691c\u51fa\u3059\u308b\u53ef\u80fd\u6027\u304c\u3042\u308a\u307e\u3059\u3002",
+  "settings.silence_threshold_label": "\u6c88\u9ed9\u95be\u5024",
+  "settings.silence_threshold_description": "\u6c88\u9ed9\u691c\u51fa\u304c\u59cb\u307e\u308b\u97f3\u91cf\u30ec\u30d9\u30eb\uff08dB\uff09\u3002\u97f3\u58f0\u95be\u5024\u3088\u308a\u4f4e\u304f\u8a2d\u5b9a\u3057\u3066\u304f\u3060\u3055\u3044\u3002\u4f4e\u3044\u5024\u306f\u80cc\u666f\u30ce\u30a4\u30ba\u3092\u3088\u308a\u8a31\u5bb9\u3057\u307e\u3059\u3002",
+  "settings.silence_duration_label": "\u6c88\u9ed9\u6642\u9593",
+  "settings.silence_duration_description": "\u9332\u97f3\u304c\u7d42\u4e86\u3059\u308b\u307e\u3067\u306b\u6c88\u9ed9\u304c\u7d9a\u304f\u5fc5\u8981\u304c\u3042\u308b\u6642\u9593\uff08ms\uff09\u3002\u9577\u3044\u5024\u306f\u81ea\u7136\u306a\u30dd\u30fc\u30ba\u3092\u8a31\u5bb9\u3057\u3001\u77ed\u3044\u5024\u306f\u9332\u97f3\u3092\u65e9\u304f\u7d42\u4e86\u3057\u307e\u3059\u3002",
+  "settings.min_recording_label": "\u6700\u5c0f\u9332\u97f3\u6642\u9593",
+  "settings.min_recording_description": "\u6c88\u9ed9\u3067\u9332\u97f3\u3092\u7d42\u4e86\u3059\u308b\u524d\u306b\u5fc5\u8981\u306a\u6700\u5c0f\u306e\u97f3\u58f0\u6642\u9593\uff08ms\uff09\u3002\u77ed\u3059\u304e\u308b\u5076\u767a\u7684\u306a\u9332\u97f3\u3092\u9632\u304e\u307e\u3059\u3002",
+  "settings.default_prefix": "\u30c7\u30d5\u30a9\u30eb\u30c8:"
+}
+```
+
+### 2. i18next initialization
+
+#### `src/i18n/index.ts`
+
+```typescript
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import { getLocales } from 'expo-localization';
+
+import en from './locales/en/translation.json';
+import ja from './locales/ja/translation.json';
+
+const SUPPORTED_LANGUAGES = ['en', 'ja'] as const;
+
+function getDeviceLanguage(): string {
+  const locales = getLocales();
+  const deviceLang = locales[0]?.languageCode ?? 'en';
+  if ((SUPPORTED_LANGUAGES as readonly string[]).includes(deviceLang)) {
+    return deviceLang;
+  }
+  return 'en';
+}
+
+i18n.use(initReactI18next).init({
+  resources: {
+    en: { translation: en },
+    ja: { translation: ja },
+  },
+  lng: getDeviceLanguage(),
+  fallbackLng: 'en',
+  supportedLngs: ['en', 'ja'],
+  interpolation: {
+    escapeValue: false, // React Native already escapes
+  },
+});
+
+export default i18n;
+```
+
+### 3. I18nProvider with per-app language listener
+
+#### `src/context/I18nProvider.tsx`
+
+When the user changes the per-app language via system settings, the app must detect this and switch `i18n.language`. The `useLocales()` hook from `expo-localization` provides reactive locale data.
+
+```typescript
+import { useEffect } from 'react';
+import { I18nextProvider } from 'react-i18next';
+import { useLocales } from 'expo-localization';
+import i18n from '../i18n';
+
+const SUPPORTED_LANGUAGES = ['en', 'ja'];
+
+export function I18nProvider({ children }: { children: React.ReactNode }) {
+  const locales = useLocales();
+
+  useEffect(() => {
+    const deviceLang = locales[0]?.languageCode ?? 'en';
+    const lang = SUPPORTED_LANGUAGES.includes(deviceLang) ? deviceLang : 'en';
+    if (i18n.language !== lang) {
+      i18n.changeLanguage(lang);
+    }
+  }, [locales]);
+
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+}
+```
+
+### 4. Integrate I18nProvider into the root layout
+
+#### `app/_layout.tsx` -- modifications
+
+The `I18nProvider` wraps the entire app tree, outermost after `GestureHandlerRootView`:
+
+```typescript
+// Add import:
+import { I18nProvider } from '../src/context/I18nProvider';
+import { useTranslation } from 'react-i18next';
+
+// Modify RootLayout:
+export default function RootLayout() {
+  return (
+    <GestureHandlerRootView style={styles.root}>
+      <I18nProvider>
+        <ServicesProvider services={isE2E ? e2eServices : realServices}>
+          <SettingsProvider repository={settingsRepository}>
+            <RootStack />
+            {isE2E && <E2EBanner />}
+            <StatusBar style="dark" />
+          </SettingsProvider>
+        </ServicesProvider>
+      </I18nProvider>
+    </GestureHandlerRootView>
+  );
+}
+
+// Extract Stack into a component so it can use useTranslation:
+function RootStack() {
+  const { t } = useTranslation();
+  return (
+    <Stack>
+      <Stack.Screen
+        name="index"
+        options={{ title: 'VoiceMirror', headerShown: false }}
+      />
+      <Stack.Screen
+        name="settings"
+        options={{ title: t('settings.title'), presentation: 'card' }}
+      />
+    </Stack>
+  );
+}
+```
+
+The `Stack.Screen` for settings must use `t('settings.title')` so the header updates when the language changes. Extracting a `RootStack` component is necessary because `useTranslation()` must be called inside the `I18nextProvider` tree.
+
+### 5. Update VoiceMirrorScreen
+
+#### `src/screens/VoiceMirrorScreen.tsx` -- modifications
+
+Replace all hardcoded strings with `t()` calls:
+
+```typescript
+import { useTranslation } from 'react-i18next';
+
+function VoiceMirrorContent() {
+  const { t } = useTranslation();
+  // ... existing code ...
+
+  if (permissionDenied) {
+    return (
+      <SafeAreaView style={styles.root}>
+        <View style={styles.center}>
+          <Text style={styles.errorTitle}>{t('main.error_title')}</Text>
+          <Text style={styles.errorBody}>{t('main.error_body')}</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!hasPermission) {
+    return (
+      <SafeAreaView style={styles.root}>
+        <View style={styles.center}>
+          <Text style={styles.hint}>{t('main.hint_requesting')}</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  // In the main return:
+  <Text style={styles.hint}>
+    {isPaused ? t('main.hint_paused') : t('main.hint_listening')}
+  </Text>
+  {recordingError && (
+    <Text style={styles.recordingError}>{t(`main.${recordingError}`)}</Text>
+  )}
+  <Text style={styles.pauseButtonLabel}>
+    {isPaused ? t('main.button_resume') : t('main.button_pause')}
+  </Text>
+```
+
+### 6. Update PhaseDisplay
+
+#### `src/components/PhaseDisplay.tsx` -- modifications
+
+Replace the `PHASE_LABEL` record with `t()` calls:
+
+```typescript
+import { useTranslation } from 'react-i18next';
+import type { Phase } from '../hooks/types';
+
+// Remove the PHASE_LABEL constant entirely.
+// The PHASE_COLOR constant stays (colors are not localized).
+
+const PHASE_I18N_KEY: Record<Phase, string> = {
+  idle: 'phase.idle',
+  recording: 'phase.recording',
+  playing: 'phase.playing',
+  paused: 'phase.paused',
+};
+
+export function PhaseDisplay({ phase }: Props) {
+  const { t } = useTranslation();
+  // ...
+  // Replace PHASE_LABEL[phase] with:
+  <Text ...>{t(PHASE_I18N_KEY[phase])}</Text>
+}
+```
+
+### 7. Update RecordingsList
+
+#### `src/components/RecordingsList.tsx` -- modifications
+
+```typescript
+import { useTranslation } from 'react-i18next';
+
+export function RecordingsList({ ... }: Props) {
+  const { t } = useTranslation();
+
+  if (recordings.length === 0) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyText}>{t('recordings.empty')}</Text>
+      </View>
+    );
+  }
+  // ...
+}
+```
+
+### 8. Update RecordingItem
+
+#### `src/components/RecordingItem.tsx` -- modifications
+
+```typescript
+import { useTranslation } from 'react-i18next';
+
+export function RecordingItem({ ... }: Props) {
+  const { t } = useTranslation();
+  // ...
+  // In renderRightActions:
+  <Text style={styles.deleteLabel}>{t('recordings.delete')}</Text>
+}
+```
+
+### 9. Update Settings screen
+
+#### `app/settings.tsx` -- modifications
+
+The `SLIDERS` array currently embeds English strings for `label` and `description`. Replace these with i18n keys and look them up with `t()`:
+
+```typescript
+import { useTranslation } from 'react-i18next';
+
+type SliderConfig = {
+  key: keyof DetectionSettings;
+  labelKey: string;       // was: label: string
+  descriptionKey: string; // was: description: string
+  min: number;
+  max: number;
+  step: number;
+  unit: string;
+};
+
+const SLIDERS: SliderConfig[] = [
+  {
+    key: 'voiceThresholdDb',
+    labelKey: 'settings.voice_threshold_label',
+    descriptionKey: 'settings.voice_threshold_description',
+    min: -60, max: -10, step: 1, unit: 'dB',
+  },
+  {
+    key: 'voiceOnsetMs',
+    labelKey: 'settings.voice_onset_label',
+    descriptionKey: 'settings.voice_onset_description',
+    min: 50, max: 1000, step: 50, unit: 'ms',
+  },
+  {
+    key: 'silenceThresholdDb',
+    labelKey: 'settings.silence_threshold_label',
+    descriptionKey: 'settings.silence_threshold_description',
+    min: -70, max: -10, step: 1, unit: 'dB',
+  },
+  {
+    key: 'silenceDurationMs',
+    labelKey: 'settings.silence_duration_label',
+    descriptionKey: 'settings.silence_duration_description',
+    min: 300, max: 5000, step: 100, unit: 'ms',
+  },
+  {
+    key: 'minRecordingMs',
+    labelKey: 'settings.min_recording_label',
+    descriptionKey: 'settings.min_recording_description',
+    min: 100, max: 3000, step: 100, unit: 'ms',
+  },
+];
+
+function SettingSlider({ config }: { config: SliderConfig }) {
+  const { t } = useTranslation();
+  const { settings, updateSetting } = useSettings();
+  const value = settings[config.key];
+
+  return (
+    <View style={styles.sliderCard}>
+      <View style={styles.sliderHeader}>
+        <Text style={styles.sliderLabel}>{t(config.labelKey)}</Text>
+        <Text style={styles.sliderValue}>
+          {value} {config.unit}
+        </Text>
+      </View>
+      <Text style={styles.sliderDescription}>{t(config.descriptionKey)}</Text>
+      {/* Slider unchanged */}
+      <View style={styles.sliderRange}>
+        <Text style={styles.rangeLabel}>
+          {config.min} {config.unit}
+        </Text>
+        <Text style={styles.defaultLabel}>
+          {t('settings.default_prefix')} {DEFAULT_SETTINGS[config.key]} {config.unit}
+        </Text>
+        <Text style={styles.rangeLabel}>
+          {config.max} {config.unit}
+        </Text>
+      </View>
+    </View>
+  );
+}
+```
+
+Note: The unit strings `"dB"` and `"ms"` are international technical abbreviations and do not need translation.
+
+### 10. Change useVoiceMirror to return an error key instead of a translated string
+
+#### `src/hooks/useVoiceMirror.ts` -- modification
+
+```typescript
+// Change this line (around line 241):
+setRecordingError('Recording failed to save.');
+
+// To:
+setRecordingError('recording_failed');
+```
+
+The component translates it as `t(`main.${recordingError}`)`. This keeps the hook free of translation concerns and aligns with the project's dependency injection pattern.
+
+### 11. Native-level localization (system permission dialog)
+
+#### `languages/ja.json` (new file at project root)
+
+```json
+{
+  "ios": {
+    "NSMicrophoneUsageDescription": "VoiceMirror\u304c\u3042\u306a\u305f\u306e\u58f0\u3092\u9332\u97f3\u3057\u3001\u3059\u3050\u306b\u518d\u751f\u3057\u307e\u3059\u3002"
+  }
+}
+```
+
+#### `app.json` -- modifications
+
+Add `locales`, `infoPlist`, and the `expo-localization` plugin:
+
+```json
+{
+  "expo": {
+    "locales": {
+      "ja": "./languages/ja.json"
+    },
+    "ios": {
+      "supportsTablet": true,
+      "bundleIdentifier": "net.tai2.voicemirror",
+      "config": {
+        "usesNonExemptEncryption": false
+      },
+      "infoPlist": {
+        "CFBundleAllowMixedLocalizations": true
+      }
+    },
+    "plugins": [
+      "./plugins/withCleartextTraffic",
+      [
+        "react-native-audio-api",
+        {
+          "iosMicrophonePermission": "VoiceMirror records your voice so you can immediately hear yourself back.",
+          "androidPermissions": ["android.permission.RECORD_AUDIO"]
+        }
+      ],
+      [
+        "expo-localization",
+        {
+          "supportedLocales": ["en", "ja"]
+        }
+      ]
+    ]
+  }
+}
+```
+
+The `expo-localization` plugin with `supportedLocales` configures:
+- **iOS**: Adds `en` and `ja` to `CFBundleLocalizations` in `Info.plist`, enabling the per-app language picker in iOS Settings > VoiceMirror > Language.
+- **Android**: Writes `res/xml/locales_config.xml` and sets `android:localeConfig` in `AndroidManifest.xml`, enabling Android's per-app language setting (Android 13+).
+
+The `CFBundleAllowMixedLocalizations: true` ensures iOS actually looks up the localized `.lproj` strings files rather than using only the base language.
+
+### 12. Update unit tests
+
+Tests that render components with translated text need an i18n context. Two approaches:
+
+**Approach A (chosen): Provide a real i18n instance in tests.**
+
+Create a test helper that initializes i18n with English translations:
+
+#### `src/__tests__/helpers/setupI18n.ts`
+
+```typescript
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from '../../i18n/locales/en/translation.json';
+
+export function setupTestI18n() {
+  if (i18n.isInitialized) return i18n;
+
+  i18n.use(initReactI18next).init({
+    resources: { en: { translation: en } },
+    lng: 'en',
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false },
+  });
+
+  return i18n;
+}
+```
+
+Tests for `useVoiceMirror` do not need this -- the hook does not use `t()` (it returns error keys). Only component tests that render text need the i18n wrapper.
+
+For component render tests, wrap the component:
+
+```typescript
+import { I18nextProvider } from 'react-i18next';
+import { setupTestI18n } from '../helpers/setupI18n';
+
+const i18n = setupTestI18n();
+
+render(
+  <I18nextProvider i18n={i18n}>
+    <PhaseDisplay phase="idle" />
+  </I18nextProvider>
+);
+```
+
+#### `src/hooks/useVoiceMirror.ts` test update
+
+The `useVoiceMirror` test file needs no i18n changes since the hook now returns an error key (`'recording_failed'`) instead of a translated string. Update assertions from:
+
+```typescript
+expect(result.current.recordingError).toBe('Recording failed to save.');
+```
+
+to:
+
+```typescript
+expect(result.current.recordingError).toBe('recording_failed');
+```
+
+### 13. Rebuild native projects
+
+After modifying `app.json` (adding `locales`, `expo-localization` plugin, `infoPlist`), a native rebuild is required:
+
+```bash
+npx expo prebuild --clean
+```
+
+This regenerates the `ios/` and `android/` directories with the new locale configuration files.
+
+## Files Summary
+
+| Action | File |
+|--------|------|
+| **Create** | `src/i18n/index.ts` |
+| **Create** | `src/i18n/locales/en/translation.json` |
+| **Create** | `src/i18n/locales/ja/translation.json` |
+| **Create** | `src/context/I18nProvider.tsx` |
+| **Create** | `languages/ja.json` |
+| **Create** | `src/__tests__/helpers/setupI18n.ts` |
+| **Modify** | `package.json` (add `i18next`, `react-i18next`, `expo-localization`) |
+| **Modify** | `app.json` (add `locales`, `infoPlist`, `expo-localization` plugin) |
+| **Modify** | `app/_layout.tsx` (wrap with `I18nProvider`, extract `RootStack`, translate settings title) |
+| **Modify** | `src/screens/VoiceMirrorScreen.tsx` (replace hardcoded strings with `t()`) |
+| **Modify** | `src/components/PhaseDisplay.tsx` (replace `PHASE_LABEL` with `t()`) |
+| **Modify** | `src/components/RecordingsList.tsx` (translate empty state) |
+| **Modify** | `src/components/RecordingItem.tsx` (translate delete label) |
+| **Modify** | `app/settings.tsx` (use i18n keys for slider labels/descriptions) |
+| **Modify** | `src/hooks/useVoiceMirror.ts` (return error key instead of English string) |
+| **Modify** | `src/__tests__/hooks/useVoiceMirror.test.ts` (update error string assertion) |
+
+## Considerations and Trade-offs
+
+### Per-App Language vs. In-App Language Picker
+
+The plan uses the native per-app language selection mechanism (iOS Settings and Android Settings) rather than building a custom language picker inside the app. This has several advantages:
+- No custom UI to build or maintain
+- Consistent with platform conventions
+- The OS handles locale persistence
+- Works even before the app is launched
+
+The trade-off is that users must navigate to system settings to change the language, which is slightly less discoverable than an in-app toggle. However, this is the pattern Apple and Google recommend, and iOS/Android users are increasingly familiar with it.
+
+### Synchronous vs. Asynchronous i18n Init
+
+Because all translations are bundled (imported as JSON modules), `i18n.init()` is synchronous. There is no loading state and no need for `useSuspense: false`. The app renders with translations immediately available. This is the simplest approach for a small translation set.
+
+### Error Key Pattern in useVoiceMirror
+
+Changing `setRecordingError('Recording failed to save.')` to `setRecordingError('recording_failed')` is a small breaking change for anything that checks the error string value. The trade-off is cleaner separation of concerns: the hook remains language-agnostic, and only the UI layer translates. This aligns with the project's existing dependency injection pattern where hooks do not depend on UI concerns.
+
+An alternative would be to have the hook accept a `t` function parameter, but this couples the hook to the i18n system unnecessarily. The error key approach is more idiomatic.
+
+### Strings Not Translated
+
+The following are intentionally NOT translated:
+- **E2E banner text** (`"E2E"`, `"WS: Connected"`, etc.) -- developer-only, not user-facing
+- **`accessibilityLabel` values** used as test IDs (`"toggle-pause-button"`, `"phase-idle"`, etc.) -- these are identifiers for E2E tests, not screen-reader text
+- **`console.error` / `console.warn` messages** -- developer diagnostics
+- **Technical units** (`"dB"`, `"ms"`) -- internationally recognized abbreviations
+- **Duration format** (`m:ss`) -- universally understood numeric format
+- **App name** `"VoiceMirror"` -- brand name, not translated
+
+### Date/Time Formatting
+
+`RecordingItem.tsx` already passes `undefined` as the locale to `toLocaleDateString()` and `toLocaleTimeString()`, which means dates are formatted according to the device locale. This is correct and independent of the app language. No changes needed.
+
+### JSON File Location Convention
+
+The `languages/ja.json` file (for native iOS/Android permission strings) lives at the project root because `app.json`'s `locales` field references paths relative to the project root. The `src/i18n/locales/` directory contains the runtime translation files used by react-i18next. These are separate concerns: one is build-time native config, the other is runtime JS translations.
+
+### Future Language Additions
+
+Adding a new language requires:
+1. Create `src/i18n/locales/<lang>/translation.json`
+2. Import and add to `resources` in `src/i18n/index.ts`
+3. Add to `SUPPORTED_LANGUAGES` in both `src/i18n/index.ts` and `src/context/I18nProvider.tsx`
+4. Add to `supportedLocales` in the `expo-localization` plugin config in `app.json`
+5. Optionally create `languages/<lang>.json` for native permission strings
+6. Run `npx expo prebuild --clean`
+
+### TypeScript Type Safety for Translation Keys
+
+The plan uses plain string keys for `t()` calls. For stronger type safety, `i18next` supports typed `t` functions via module augmentation:
+
+```typescript
+import 'i18next';
+import type en from './locales/en/translation.json';
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'translation';
+    resources: {
+      translation: typeof en;
+    };
+  }
+}
+```
+
+This enables autocompletion and compile-time key validation. It is optional but recommended. If adopted, it should be added to `src/i18n/index.ts` or a dedicated `src/i18n/types.d.ts` file.
+
+## Todo
+
+### Phase 1: Install dependencies
+- [x]Run `pnpm add i18next react-i18next expo-localization`
+
+### Phase 2: Create translation files
+- [x]Create `src/i18n/locales/en/translation.json` with all English strings
+- [x]Create `src/i18n/locales/ja/translation.json` with all Japanese strings
+
+### Phase 3: i18next initialization
+- [x]Create `src/i18n/index.ts` with i18next init, resource imports, `getDeviceLanguage()` helper, and `SUPPORTED_LANGUAGES` constant
+
+### Phase 4: I18nProvider
+- [x]Create `src/context/I18nProvider.tsx` with `useLocales()` listener that syncs `i18n.language` on per-app language change
+
+### Phase 5: Integrate I18nProvider into root layout
+- [x]Add `I18nProvider` import to `app/_layout.tsx`
+- [x]Wrap the app tree with `<I18nProvider>` inside `GestureHandlerRootView`
+- [x]Extract `RootStack` component from `RootLayout` so `useTranslation()` can be called inside the provider
+- [x]Replace hardcoded `"Settings"` title in `Stack.Screen` with `t('settings.title')`
+
+### Phase 6: Update VoiceMirrorScreen
+- [x]Add `useTranslation` import to `src/screens/VoiceMirrorScreen.tsx`
+- [x]Replace permission-denied error title and body with `t('main.error_title')` and `t('main.error_body')`
+- [x]Replace "Requesting microphone access" hint with `t('main.hint_requesting')`
+- [x]Replace paused/listening hint text with `t('main.hint_paused')` and `t('main.hint_listening')`
+- [x]Replace recording error display to use `t(`main.${recordingError}`)` for translated error messages
+- [x]Replace "Resume"/"Pause" button labels with `t('main.button_resume')` and `t('main.button_pause')`
+
+### Phase 7: Update PhaseDisplay
+- [x]Add `useTranslation` import to `src/components/PhaseDisplay.tsx`
+- [x]Remove the `PHASE_LABEL` constant
+- [x]Add `PHASE_I18N_KEY` mapping from `Phase` to translation keys
+- [x]Replace `PHASE_LABEL[phase]` usage with `t(PHASE_I18N_KEY[phase])`
+
+### Phase 8: Update RecordingsList
+- [x]Add `useTranslation` import to `src/components/RecordingsList.tsx`
+- [x]Replace hardcoded "No recordings yet" with `t('recordings.empty')`
+
+### Phase 9: Update RecordingItem
+- [x]Add `useTranslation` import to `src/components/RecordingItem.tsx`
+- [x]Replace hardcoded "Delete" label with `t('recordings.delete')`
+
+### Phase 10: Update Settings screen
+- [x]Add `useTranslation` import to `app/settings.tsx`
+- [x]Change `SliderConfig` type: replace `label`/`description` fields with `labelKey`/`descriptionKey`
+- [x]Update `SLIDERS` array entries to use i18n keys instead of English strings
+- [x]Update `SettingSlider` component to call `t(config.labelKey)` and `t(config.descriptionKey)`
+- [x]Update default value prefix to use `t('settings.default_prefix')`
+
+### Phase 11: Change useVoiceMirror error to return a key
+- [x]In `src/hooks/useVoiceMirror.ts`, change `setRecordingError('Recording failed to save.')` to `setRecordingError('recording_failed')`
+
+### Phase 12: Native-level localization
+- [x]Create `languages/ja.json` with Japanese `NSMicrophoneUsageDescription`
+- [x]Add `"locales": { "ja": "./languages/ja.json" }` to `app.json` under `expo`
+- [x]Add `"infoPlist": { "CFBundleAllowMixedLocalizations": true }` to `app.json` under `expo.ios`
+- [x]Add `["expo-localization", { "supportedLocales": ["en", "ja"] }]` to `plugins` array in `app.json`
+
+### Phase 13: Update unit tests
+- [x]Create `src/__tests__/helpers/setupI18n.ts` test helper that initializes i18n with English translations
+- [x]Update `src/hooks/__tests__/useVoiceMirror.test.ts`: change error assertion from `'Recording failed to save.'` to `'recording_failed'`
+- [x]Update `src/components/__tests__/PhaseDisplay.test.tsx`: wrap rendered component with `I18nextProvider` using the test i18n instance
+- [x]Update `src/components/__tests__/RecordingItem.test.tsx`: wrap rendered component with `I18nextProvider` using the test i18n instance
+
+### Phase 14: Verification
+- [x]Run `pnpm typecheck` and fix any type errors
+- [x]Run `pnpm lint` and fix any lint issues
+- [x]Run `pnpm test:ci` and verify all unit tests pass
+- [x] Run `npx expo prebuild --clean` to regenerate native projects with locale configuration

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,15 +26,24 @@ importers:
       expo-file-system:
         specifier: ^55.0.11
         version: 55.0.11(expo@55.0.5)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))
+      expo-localization:
+        specifier: ^55.0.9
+        version: 55.0.9(expo@55.0.5)(react@19.2.0)
       expo-router:
         specifier: ^55.0.7
-        version: 55.0.7(@expo/log-box@55.0.7)(@expo/metro-runtime@55.0.6)(@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@25.5.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0))(@types/react@19.2.14)(expo-constants@55.0.7)(expo-font@55.0.4)(expo-linking@55.0.8)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react-native-gesture-handler@2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.7.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-screens@4.24.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+        version: 55.0.7(@expo/log-box@55.0.7)(@expo/metro-runtime@55.0.6)(@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@25.5.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0))(@types/react@19.2.14)(expo-constants@55.0.9)(expo-font@55.0.4)(expo-linking@55.0.8)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react-native-gesture-handler@2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.7.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-screens@4.24.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       expo-status-bar:
         specifier: ~55.0.4
         version: 55.0.4(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      i18next:
+        specifier: ^25.10.10
+        version: 25.10.10(typescript@5.9.3)
       react:
         specifier: 19.2.0
         version: 19.2.0
+      react-i18next:
+        specifier: ^16.6.6
+        version: 16.6.6(i18next@25.10.10(typescript@5.9.3))(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react-native:
         specifier: 0.83.2
         version: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
@@ -633,6 +642,10 @@ packages:
 
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
@@ -3625,6 +3638,12 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-localization@55.0.9:
+    resolution: {integrity: sha512-ABRg4wEt15OCp9/3XOLC4ltPVvXmJgeCKNTJ4Nb8N6byuHITJHvZ3PwcC2YGpTzlAqfGbcs3rJdfg1ObT54PJQ==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+
   expo-manifests@55.0.9:
     resolution: {integrity: sha512-i82j3X4hbxYDe6kxUw4u8WfvbvTj2w+9BD9WKuL0mFRy+MjvdzdyaqAjEViWCKo/alquP/hTApDTQBb3UmWhkg==}
     peerDependencies:
@@ -4100,6 +4119,9 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  html-parse-stringify@3.0.1:
+    resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
   htmlfy@0.8.1:
     resolution: {integrity: sha512-xWROBw9+MEGwxpotll0h672KCaLrKKiCYzsyN8ZgL9cQbVumFnyvsk2JqiB9ELAV1GLj1GG/jxZUjV9OZZi/yQ==}
 
@@ -4139,6 +4161,14 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  i18next@25.10.10:
+    resolution: {integrity: sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==}
+    peerDependencies:
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -5699,6 +5729,22 @@ packages:
     peerDependencies:
       react: '>=17.0.0'
 
+  react-i18next@16.6.6:
+    resolution: {integrity: sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==}
+    peerDependencies:
+      i18next: '>= 25.10.9'
+      react: '>= 16.8.0'
+      react-dom: '*'
+      react-native: '*'
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+      typescript:
+        optional: true
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -5945,6 +5991,9 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  rtl-detect@1.1.2:
+    resolution: {integrity: sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==}
 
   run-async@4.0.6:
     resolution: {integrity: sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==}
@@ -6691,6 +6740,10 @@ packages:
 
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
+
+  void-elements@3.1.0:
+    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
+    engines: {node: '>=0.10.0'}
 
   w3c-xmlserializer@4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
@@ -7665,6 +7718,8 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -7844,7 +7899,7 @@ snapshots:
 
   '@expo-google-fonts/material-symbols@0.4.27': {}
 
-  '@expo/cli@55.0.15(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-constants@55.0.7)(expo-font@55.0.4)(expo-router@55.0.7)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
+  '@expo/cli@55.0.15(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-constants@55.0.7(expo@55.0.5)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(typescript@5.9.3))(expo-font@55.0.4)(expo-router@55.0.7)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 55.0.8(typescript@5.9.3)
@@ -7861,7 +7916,7 @@ snapshots:
       '@expo/plist': 0.5.2
       '@expo/prebuild-config': 55.0.8(expo@55.0.5)(typescript@5.9.3)
       '@expo/require-utils': 55.0.2(typescript@5.9.3)
-      '@expo/router-server': 55.0.9(@expo/metro-runtime@55.0.6)(expo-constants@55.0.7)(expo-font@55.0.4)(expo-router@55.0.7)(expo-server@55.0.6)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
+      '@expo/router-server': 55.0.9(@expo/metro-runtime@55.0.6)(expo-constants@55.0.7(expo@55.0.5)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(typescript@5.9.3))(expo-font@55.0.4)(expo-router@55.0.7)(expo-server@55.0.6)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)
       '@expo/schema-utils': 55.0.2
       '@expo/spawn-async': 1.7.2
       '@expo/ws-tunnel': 1.0.6
@@ -7905,7 +7960,7 @@ snapshots:
       ws: 8.20.0
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.7(@expo/log-box@55.0.7)(@expo/metro-runtime@55.0.6)(@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@25.5.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0))(@types/react@19.2.14)(expo-constants@55.0.7)(expo-font@55.0.4)(expo-linking@55.0.8)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react-native-gesture-handler@2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.7.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-screens@4.24.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      expo-router: 55.0.7(@expo/log-box@55.0.7)(@expo/metro-runtime@55.0.6)(@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@25.5.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0))(@types/react@19.2.14)(expo-constants@55.0.9)(expo-font@55.0.4)(expo-linking@55.0.8)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react-native-gesture-handler@2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.7.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-screens@4.24.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -8175,7 +8230,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/router-server@55.0.9(@expo/metro-runtime@55.0.6)(expo-constants@55.0.7)(expo-font@55.0.4)(expo-router@55.0.7)(expo-server@55.0.6)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)':
+  '@expo/router-server@55.0.9(@expo/metro-runtime@55.0.6)(expo-constants@55.0.7(expo@55.0.5)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(typescript@5.9.3))(expo-font@55.0.4)(expo-router@55.0.7)(expo-server@55.0.6)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react@19.2.0)':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       expo: 55.0.5(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.7)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
@@ -8185,7 +8240,7 @@ snapshots:
       react: 19.2.0
     optionalDependencies:
       '@expo/metro-runtime': 55.0.6(@expo/dom-webview@55.0.3)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
-      expo-router: 55.0.7(@expo/log-box@55.0.7)(@expo/metro-runtime@55.0.6)(@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@25.5.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0))(@types/react@19.2.14)(expo-constants@55.0.7)(expo-font@55.0.4)(expo-linking@55.0.8)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react-native-gesture-handler@2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.7.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-screens@4.24.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      expo-router: 55.0.7(@expo/log-box@55.0.7)(@expo/metro-runtime@55.0.6)(@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@25.5.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0))(@types/react@19.2.14)(expo-constants@55.0.9)(expo-font@55.0.4)(expo-linking@55.0.8)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react-native-gesture-handler@2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.7.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-screens@4.24.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.4(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -11526,6 +11581,12 @@ snapshots:
       - supports-color
       - typescript
 
+  expo-localization@55.0.9(expo@55.0.5)(react@19.2.0):
+    dependencies:
+      expo: 55.0.5(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.7)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      react: 19.2.0
+      rtl-detect: 1.1.2
+
   expo-manifests@55.0.9(expo@55.0.5)(typescript@5.9.3):
     dependencies:
       '@expo/config': 55.0.8(typescript@5.9.3)
@@ -11551,7 +11612,7 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
 
-  expo-router@55.0.7(@expo/log-box@55.0.7)(@expo/metro-runtime@55.0.6)(@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@25.5.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0))(@types/react@19.2.14)(expo-constants@55.0.7)(expo-font@55.0.4)(expo-linking@55.0.8)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react-native-gesture-handler@2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.7.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-screens@4.24.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
+  expo-router@55.0.7(@expo/log-box@55.0.7)(@expo/metro-runtime@55.0.6)(@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@25.5.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0))(@types/react@19.2.14)(expo-constants@55.0.9)(expo-font@55.0.4)(expo-linking@55.0.8)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react-native-gesture-handler@2.30.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.7.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native-screens@4.24.0(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
     dependencies:
       '@expo/log-box': 55.0.7(@expo/dom-webview@55.0.3)(expo@55.0.5)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       '@expo/metro-runtime': 55.0.6(@expo/dom-webview@55.0.3)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -11565,7 +11626,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       expo: 55.0.5(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.7)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      expo-constants: 55.0.7(expo@55.0.5)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(typescript@5.9.3)
+      expo-constants: 55.0.9(expo@55.0.5)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(typescript@5.9.3)
       expo-glass-effect: 55.0.8(expo@55.0.5)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       expo-image: 55.0.6(expo@55.0.5)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       expo-linking: 55.0.8(expo@55.0.5)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
@@ -11622,7 +11683,7 @@ snapshots:
   expo@55.0.5(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.7)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.28.6
-      '@expo/cli': 55.0.15(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-constants@55.0.7)(expo-font@55.0.4)(expo-router@55.0.7)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@expo/cli': 55.0.15(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-constants@55.0.7(expo@55.0.5)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(typescript@5.9.3))(expo-font@55.0.4)(expo-router@55.0.7)(expo@55.0.5)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@expo/config': 55.0.8(typescript@5.9.3)
       '@expo/config-plugins': 55.0.7
       '@expo/devtools': 55.0.2(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -12075,6 +12136,10 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  html-parse-stringify@3.0.1:
+    dependencies:
+      void-elements: 3.1.0
+
   htmlfy@0.8.1: {}
 
   htmlparser2@10.1.0:
@@ -12129,6 +12194,12 @@ snapshots:
   human-signals@2.1.0: {}
 
   human-signals@8.0.1: {}
+
+  i18next@25.10.10(typescript@5.9.3):
+    dependencies:
+      '@babel/runtime': 7.29.2
+    optionalDependencies:
+      typescript: 5.9.3
 
   iconv-lite@0.6.3:
     dependencies:
@@ -14156,6 +14227,18 @@ snapshots:
     dependencies:
       react: 19.2.0
 
+  react-i18next@16.6.6(i18next@25.10.10(typescript@5.9.3))(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      html-parse-stringify: 3.0.1
+      i18next: 25.10.10(typescript@5.9.3)
+      react: 19.2.0
+      use-sync-external-store: 1.6.0(react@19.2.0)
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.0)
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+      typescript: 5.9.3
+
   react-is@16.13.1: {}
 
   react-is@18.3.1: {}
@@ -14469,6 +14552,8 @@ snapshots:
       path-to-regexp: 8.3.0
     transitivePeerDependencies:
       - supports-color
+
+  rtl-detect@1.1.2: {}
 
   run-async@4.0.6: {}
 
@@ -15323,6 +15408,8 @@ snapshots:
       - '@types/react-dom'
 
   vlq@1.0.1: {}
+
+  void-elements@3.1.0: {}
 
   w3c-xmlserializer@4.0.0:
     dependencies:

--- a/src/__tests__/helpers/setupI18n.ts
+++ b/src/__tests__/helpers/setupI18n.ts
@@ -1,0 +1,16 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import en from "../../i18n/locales/en/translation.json";
+
+export function setupTestI18n() {
+  if (i18n.isInitialized) return i18n;
+
+  i18n.use(initReactI18next).init({
+    resources: { en: { translation: en } },
+    lng: "en",
+    fallbackLng: "en",
+    interpolation: { escapeValue: false },
+  });
+
+  return i18n;
+}

--- a/src/components/PhaseDisplay.tsx
+++ b/src/components/PhaseDisplay.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef } from 'react';
 import { View, Text, Animated, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import type { Phase } from '../hooks/types';
 
-const PHASE_LABEL: Record<Phase, string> = {
-  idle: 'Listening…',
-  recording: 'Recording',
-  playing: 'Playing back',
-  paused: 'Paused',
+const PHASE_I18N_KEY: Record<Phase, string> = {
+  idle: 'phase.idle',
+  recording: 'phase.recording',
+  playing: 'phase.playing',
+  paused: 'phase.paused',
 };
 
 const PHASE_COLOR: Record<Phase, string> = {
@@ -19,6 +20,7 @@ const PHASE_COLOR: Record<Phase, string> = {
 type Props = { phase: Phase };
 
 export function PhaseDisplay({ phase }: Props) {
+  const { t } = useTranslation();
   const pulse = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -42,7 +44,7 @@ export function PhaseDisplay({ phase }: Props) {
   return (
     <View style={styles.container}>
       <Animated.View style={[styles.dot, { backgroundColor: color, opacity: pulse }]} />
-      <Text testID={`phase-${phase}`} accessibilityLabel={`phase-${phase}`} style={[styles.label, { color }]}>{PHASE_LABEL[phase]}</Text>
+      <Text testID={`phase-${phase}`} accessibilityLabel={`phase-${phase}`} style={[styles.label, { color }]}>{t(PHASE_I18N_KEY[phase])}</Text>
     </View>
   );
 }

--- a/src/components/RecordingItem.tsx
+++ b/src/components/RecordingItem.tsx
@@ -1,6 +1,7 @@
 import { View, Text, Pressable, StyleSheet, Animated, useWindowDimensions } from 'react-native';
 import { Swipeable } from 'react-native-gesture-handler';
 import { useRef, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { Recording } from '../lib/recordings';
 import type { PlayState } from '../hooks/useRecordings';
 
@@ -32,6 +33,7 @@ type Props = {
 };
 
 export function RecordingItem({ recording, playState, onTogglePlay, onDelete, disabled }: Props) {
+  const { t } = useTranslation();
   const isPlaying = playState?.recordingId === recording.id && playState.isPlaying;
   const swipeableRef = useRef<Swipeable>(null);
   const { width: screenWidth } = useWindowDimensions();
@@ -70,7 +72,7 @@ export function RecordingItem({ recording, playState, onTogglePlay, onDelete, di
           style={styles.deleteButton}
         >
           <Text style={styles.deleteIcon}>🗑</Text>
-          <Text style={styles.deleteLabel}>Delete</Text>
+          <Text style={styles.deleteLabel}>{t('recordings.delete')}</Text>
         </Pressable>
       </Animated.View>
     );

--- a/src/components/RecordingsList.tsx
+++ b/src/components/RecordingsList.tsx
@@ -1,4 +1,5 @@
 import { FlatList, View, Text, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import type { Recording } from '../lib/recordings';
 import type { PlayState } from '../hooks/useRecordings';
 import { RecordingItem } from './RecordingItem';
@@ -12,10 +13,12 @@ type Props = {
 };
 
 export function RecordingsList({ recordings, playState, onTogglePlay, onDelete, disabled }: Props) {
+  const { t } = useTranslation();
+
   if (recordings.length === 0) {
     return (
       <View style={styles.empty}>
-        <Text style={styles.emptyText}>No recordings yet</Text>
+        <Text style={styles.emptyText}>{t('recordings.empty')}</Text>
       </View>
     );
   }

--- a/src/components/__tests__/PhaseDisplay.test.tsx
+++ b/src/components/__tests__/PhaseDisplay.test.tsx
@@ -1,24 +1,32 @@
 import { render, screen } from '@testing-library/react-native';
+import { I18nextProvider } from 'react-i18next';
+import { setupTestI18n } from '../../__tests__/helpers/setupI18n';
 import { PhaseDisplay } from '../PhaseDisplay';
+
+const i18n = setupTestI18n();
+
+function renderWithI18n(ui: React.ReactElement) {
+  return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>);
+}
 
 describe('PhaseDisplay', () => {
   it('shows "Listening…" in idle phase', () => {
-    render(<PhaseDisplay phase="idle" />);
+    renderWithI18n(<PhaseDisplay phase="idle" />);
     expect(screen.getByText('Listening…')).toBeTruthy();
   });
 
   it('shows "Recording" in recording phase', () => {
-    render(<PhaseDisplay phase="recording" />);
+    renderWithI18n(<PhaseDisplay phase="recording" />);
     expect(screen.getByText('Recording')).toBeTruthy();
   });
 
   it('shows "Playing back" in playing phase', () => {
-    render(<PhaseDisplay phase="playing" />);
+    renderWithI18n(<PhaseDisplay phase="playing" />);
     expect(screen.getByText('Playing back')).toBeTruthy();
   });
 
   it('shows "Paused" in paused phase', () => {
-    render(<PhaseDisplay phase="paused" />);
+    renderWithI18n(<PhaseDisplay phase="paused" />);
     expect(screen.getByText('Paused')).toBeTruthy();
   });
 });

--- a/src/components/__tests__/RecordingItem.test.tsx
+++ b/src/components/__tests__/RecordingItem.test.tsx
@@ -1,4 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react-native';
+import { I18nextProvider } from 'react-i18next';
+import { setupTestI18n } from '../../__tests__/helpers/setupI18n';
 import { RecordingItem } from '../RecordingItem';
 import type { Recording } from '../../lib/recordings';
 
@@ -9,6 +11,8 @@ jest.mock('react-native-gesture-handler', () => {
     GestureHandlerRootView: RN.View,
   };
 });
+
+const i18n = setupTestI18n();
 
 const makeRecording = (overrides?: Partial<Recording>): Recording => ({
   id: '1',
@@ -27,7 +31,11 @@ function renderItem(props: Partial<React.ComponentProps<typeof RecordingItem>> =
     disabled: false,
     ...props,
   };
-  return render(<RecordingItem {...defaultProps} />);
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <RecordingItem {...defaultProps} />
+    </I18nextProvider>,
+  );
 }
 
 describe('RecordingItem', () => {

--- a/src/context/I18nProvider.tsx
+++ b/src/context/I18nProvider.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+import { I18nextProvider } from "react-i18next";
+import { useLocales } from "expo-localization";
+import i18n from "../i18n";
+
+const SUPPORTED_LANGUAGES = ["en", "ja"];
+
+export function I18nProvider({ children }: { children: React.ReactNode }) {
+  const locales = useLocales();
+
+  useEffect(() => {
+    const deviceLang = locales[0]?.languageCode ?? "en";
+    const lang = SUPPORTED_LANGUAGES.includes(deviceLang) ? deviceLang : "en";
+    if (i18n.language !== lang) {
+      i18n.changeLanguage(lang);
+    }
+  }, [locales]);
+
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+}

--- a/src/hooks/__tests__/useVoiceMirror.test.ts
+++ b/src/hooks/__tests__/useVoiceMirror.test.ts
@@ -290,7 +290,7 @@ describe('useVoiceMirror — recording → playing', () => {
     });
 
     await waitFor(() => expect(result.current.recordingError).not.toBeNull());
-    expect(result.current.recordingError).toBe('Recording failed to save.');
+    expect(result.current.recordingError).toBe('recording_failed');
   });
 });
 

--- a/src/hooks/useVoiceMirror.ts
+++ b/src/hooks/useVoiceMirror.ts
@@ -238,7 +238,7 @@ export function useVoiceMirror(
 
     if (filePath && durationMs === 0) {
       repository.deleteFile(filePath);
-      setRecordingError('Recording failed to save.');
+      setRecordingError('recording_failed');
     }
 
     if (filePath && durationMs > 0) {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,32 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import { getLocales } from "expo-localization";
+
+import en from "./locales/en/translation.json";
+import ja from "./locales/ja/translation.json";
+
+const SUPPORTED_LANGUAGES = ["en", "ja"] as const;
+
+function getDeviceLanguage(): string {
+  const locales = getLocales();
+  const deviceLang = locales[0]?.languageCode ?? "en";
+  if ((SUPPORTED_LANGUAGES as readonly string[]).includes(deviceLang)) {
+    return deviceLang;
+  }
+  return "en";
+}
+
+i18n.use(initReactI18next).init({
+  resources: {
+    en: { translation: en },
+    ja: { translation: ja },
+  },
+  lng: getDeviceLanguage(),
+  fallbackLng: "en",
+  supportedLngs: ["en", "ja"],
+  interpolation: {
+    escapeValue: false,
+  },
+});
+
+export default i18n;

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -1,0 +1,31 @@
+{
+  "main.error_title": "Microphone access required",
+  "main.error_body": "Go to Settings → VoiceMirror → Microphone and allow access.",
+  "main.hint_requesting": "Requesting microphone access…",
+  "main.hint_paused": "Monitoring paused.",
+  "main.hint_listening": "Speak to begin. Silence ends the take.",
+  "main.button_resume": "Resume",
+  "main.button_pause": "Pause",
+  "main.recording_failed": "Recording failed to save.",
+
+  "phase.idle": "Listening…",
+  "phase.recording": "Recording",
+  "phase.playing": "Playing back",
+  "phase.paused": "Paused",
+
+  "recordings.empty": "No recordings yet",
+  "recordings.delete": "Delete",
+
+  "settings.title": "Settings",
+  "settings.voice_threshold_label": "Voice Threshold",
+  "settings.voice_threshold_description": "Audio level (in dB) that must be exceeded to begin voice onset detection. Lower values make detection more sensitive to quiet speech; higher values require louder input.",
+  "settings.voice_onset_label": "Voice Onset Duration",
+  "settings.voice_onset_description": "How long (in ms) the audio must stay above the voice threshold before recording starts. Shorter values react faster but may trigger on brief noises; longer values are more conservative.",
+  "settings.silence_threshold_label": "Silence Threshold",
+  "settings.silence_threshold_description": "Audio level (in dB) below which silence detection begins. Should be lower than the voice threshold. Lower values tolerate more background noise before ending a recording.",
+  "settings.silence_duration_label": "Silence Duration",
+  "settings.silence_duration_description": "How long (in ms) silence must persist before the recording ends. Longer values allow natural pauses in speech without cutting off; shorter values end recordings faster.",
+  "settings.min_recording_label": "Min Recording Duration",
+  "settings.min_recording_description": "Minimum amount of speech (in ms) that must be captured before silence can end the recording. Prevents very short accidental recordings.",
+  "settings.default_prefix": "default:"
+}

--- a/src/i18n/locales/ja/translation.json
+++ b/src/i18n/locales/ja/translation.json
@@ -1,0 +1,31 @@
+{
+  "main.error_title": "マイクへのアクセスが必要です",
+  "main.error_body": "設定 → VoiceMirror → マイクからアクセスを許可してください。",
+  "main.hint_requesting": "マイクへのアクセスをリクエスト中…",
+  "main.hint_paused": "モニタリング一時停止中",
+  "main.hint_listening": "話しかけてください。沈黙で終了します。",
+  "main.button_resume": "再開",
+  "main.button_pause": "一時停止",
+  "main.recording_failed": "録音の保存に失敗しました。",
+
+  "phase.idle": "待機中…",
+  "phase.recording": "録音中",
+  "phase.playing": "再生中",
+  "phase.paused": "一時停止",
+
+  "recordings.empty": "録音はまだありません",
+  "recordings.delete": "削除",
+
+  "settings.title": "設定",
+  "settings.voice_threshold_label": "音声閾値",
+  "settings.voice_threshold_description": "音声検出を開始するために超える必要がある音量レベル（dB）。低い値は小さな声に敏感になり、高い値はより大きな入力を必要とします。",
+  "settings.voice_onset_label": "音声開始時間",
+  "settings.voice_onset_description": "録音が開始されるまでに音声閾値を超え続ける必要がある時間（ms）。短い値は反応が早くなりますが短い雑音で誤検出する可能性があります。",
+  "settings.silence_threshold_label": "沈黙閾値",
+  "settings.silence_threshold_description": "沈黙検出が始まる音量レベル（dB）。音声閾値より低く設定してください。低い値は背景ノイズをより許容します。",
+  "settings.silence_duration_label": "沈黙時間",
+  "settings.silence_duration_description": "録音が終了するまでに沈黙が続く必要がある時間（ms）。長い値は自然なポーズを許容し、短い値は録音を早く終了します。",
+  "settings.min_recording_label": "最小録音時間",
+  "settings.min_recording_description": "沈黙で録音を終了する前に必要な最小の音声時間（ms）。短すぎる偶発的な録音を防ぎます。",
+  "settings.default_prefix": "デフォルト:"
+}

--- a/src/screens/VoiceMirrorScreen.tsx
+++ b/src/screens/VoiceMirrorScreen.tsx
@@ -1,6 +1,7 @@
 import { View, Text, StyleSheet, SafeAreaView, Pressable } from "react-native";
 import { useRef, useCallback } from "react";
 import { useRouter } from "expo-router";
+import { useTranslation } from "react-i18next";
 import { useVoiceMirror } from "../hooks/useVoiceMirror";
 import { useRecordings } from "../hooks/useRecordings";
 import { AudioLevelMeter } from "../components/AudioLevelMeter";
@@ -14,6 +15,7 @@ import { useServices } from "../context/ServicesProvider";
 import { useSettings } from "../context/SettingsProvider";
 
 function VoiceMirrorContent() {
+  const { t } = useTranslation();
   const audioContext = useAudioContext();
   const {
     recordingService,
@@ -75,9 +77,9 @@ function VoiceMirrorContent() {
     return (
       <SafeAreaView style={styles.root}>
         <View style={styles.center}>
-          <Text style={styles.errorTitle}>Microphone access required</Text>
+          <Text style={styles.errorTitle}>{t('main.error_title')}</Text>
           <Text style={styles.errorBody}>
-            Go to Settings → VoiceMirror → Microphone and allow access.
+            {t('main.error_body')}
           </Text>
         </View>
       </SafeAreaView>
@@ -88,7 +90,7 @@ function VoiceMirrorContent() {
     return (
       <SafeAreaView style={styles.root}>
         <View style={styles.center}>
-          <Text style={styles.hint}>Requesting microphone access…</Text>
+          <Text style={styles.hint}>{t('main.hint_requesting')}</Text>
         </View>
       </SafeAreaView>
     );
@@ -114,12 +116,10 @@ function VoiceMirrorContent() {
           <AudioLevelMeter history={levelHistory} phase={phase} />
         </View>
         <Text style={styles.hint}>
-          {isPaused
-            ? "Monitoring paused."
-            : "Speak to begin. Silence ends the take."}
+          {isPaused ? t('main.hint_paused') : t('main.hint_listening')}
         </Text>
         {recordingError && (
-          <Text style={styles.recordingError}>{recordingError}</Text>
+          <Text style={styles.recordingError}>{t(`main.${recordingError}`)}</Text>
         )}
         <Pressable
           testID="toggle-pause-button"
@@ -131,7 +131,7 @@ function VoiceMirrorContent() {
           ]}
         >
           <Text style={styles.pauseButtonLabel}>
-            {isPaused ? "Resume" : "Pause"}
+            {isPaused ? t('main.button_resume') : t('main.button_pause')}
           </Text>
         </Pressable>
       </View>


### PR DESCRIPTION
## Summary
- Integrate `i18next`, `react-i18next`, and `expo-localization` for full i18n support
- Add English and Japanese translations for all ~30 user-facing strings
- Enable per-app language selection via iOS/Android system settings (no in-app picker needed)
- Localize native iOS microphone permission dialog
- Hooks return error keys instead of English strings, keeping translation concerns in the UI layer

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test:ci` passes (63 tests)
- [x] `npx expo prebuild --clean` succeeds
- [x] Verify app displays English strings by default
- [x] Change device/per-app language to Japanese and verify all strings update
- [x] Verify iOS Settings → VoiceMirror → Language shows English/Japanese options
- [ ] Verify Android per-app language setting (Android 13+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)