### PR TITLE
fix: stop recording-phase animation on cleanup to prevent leak

### DIFF
--- a/src/components/PhaseDisplay.tsx
+++ b/src/components/PhaseDisplay.tsx
@@ -46,27 +46,30 @@ export function PhaseDisplay({ phase }: Props) {
       ]),
     );
 
+    const recordingScaleAnimation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(scale, { toValue: 1.2, duration: 500, useNativeDriver: true }),
+        Animated.timing(scale, { toValue: 1.0, duration: 500, useNativeDriver: true }),
+      ]),
+    );
+
     if (phase === 'idle') {
       pulseAnimation.start();
       scaleAnimation.start();
     } else if (phase === 'recording') {
       pulse.setValue(1);
-      Animated.loop(
-        Animated.sequence([
-          Animated.timing(scale, { toValue: 1.2, duration: 500, useNativeDriver: true }),
-          Animated.timing(scale, { toValue: 1.0, duration: 500, useNativeDriver: true }),
-        ]),
-      ).start();
+      recordingScaleAnimation.start();
     } else {
       pulseAnimation.stop();
       scaleAnimation.stop();
       pulse.setValue(1);
       scale.setValue(1);
     }
-    
+
     return () => {
       pulseAnimation.stop();
       scaleAnimation.stop();
+      recordingScaleAnimation.stop();
     };
   }, [phase, pulse, scale]);
 


### PR DESCRIPTION
## Summary
- The recording-phase scale animation in `PhaseDisplay` was created inline and started without capturing its reference, so the effect cleanup could never stop it
- Captured the animation in a variable (`recordingScaleAnimation`) and added `.stop()` to the cleanup function

## Test plan
- [x] Verify recording animation still plays correctly during `recording` phase
- [ ] Verify no animation leak warnings when switching phases rapidly

🤖 Generated with [Claude Code](https://claude.com/claude-code)