### PR TITLE
fix: suspend audioContext in pauseMonitoring to restore playback from paused state

### DIFF
--- a/src/hooks/useVoiceMirror.ts
+++ b/src/hooks/useVoiceMirror.ts
@@ -171,6 +171,7 @@ export function useVoiceMirror(
     setRecordingError(null);
 
     await recordingService.setAudioSessionActivity(true);
+    await context.resume();
     recorder.start();
 
     recorder.onAudioReady(
@@ -300,6 +301,7 @@ export function useVoiceMirror(
       repository.deleteFile(filePath);
     }
 
+    await audioContextRef.current?.suspend();
     await recordingService.setAudioSessionActivity(false);
     phaseRef.current = 'paused';
     setPhase('paused');


### PR DESCRIPTION
## Summary
- Fixed a bug where playing a recording after pausing the app produced no sound
- Added `audioContext.suspend()` in `pauseMonitoring()` so the context is properly suspended when entering paused state
- Added `audioContext.resume()` in `startMonitoring()` to ensure the context is resumed when leaving paused state

## Repro steps (before fix)
1. App is in "idle" phase
2. Tap play button of a recording (sound plays)
3. Tap pause button of the recording
4. Tap the "Pause" button to transition to "paused" phase
5. Tap play button of the recording → **no sound**

## Root cause
`pauseMonitoring()` deactivated the iOS audio session but did not suspend the `audioContext`. On iOS, deactivating the session disconnects audio hardware, but the context still reports "running" state. When `suspendForListPlayback()` later calls `audioContext.resume()`, it's a no-op, so audio output never reconnects.

## Test plan
- [x] All 111 existing unit tests pass
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] Manual test: follow the repro steps above and verify sound plays in step 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)