### PR TITLE
fix: increase silence duration default and max

### DIFF
--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -71,7 +71,7 @@ const SLIDERS: SliderConfig[] = [
     labelKey: "settings.silence_duration_label",
     descriptionKey: "settings.silence_duration_description",
     min: 100,
-    max: 3000,
+    max: 10000,
     step: 100,
     unit: "ms",
   },

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -12,7 +12,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   voiceThresholdDb: -35,
   voiceOnsetMs: 250,
   silenceThresholdDb: -45,
-  silenceDurationMs: 500,
+  silenceDurationMs: 1000,
   minRecordingMs: 500,
   maxRecordings: 20,
   maxRecordingMs: 60000,


### PR DESCRIPTION
## Summary
- Increase default silence duration from 500ms to 1000ms for more natural pause detection
- Raise max silence duration slider from 3000ms to 10000ms to allow longer pauses before cutoff

## Test plan
- [x] Open settings and verify silence duration slider range goes up to 10000ms
- [x] Reset settings and verify default silence duration is 1000ms
- [ ] Test recording with various silence duration values

🤖 Generated with [Claude Code](https://claude.com/claude-code)