### PR TITLE
feat: apply teal UI design refresh

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -24,7 +24,7 @@ const colors = {
   border: "#2A2A2E",
   textPrimary: "#FAFAFA",
   textSecondary: "#A1A1AA",
-  accent: "#3B82F6",
+  accent: "#2DD4BF",
 };
 
 const isE2E = process.env.EXPO_PUBLIC_E2E === "1";

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -22,8 +22,8 @@ const colors = {
   textPrimary: "#FAFAFA",
   textSecondary: "#A1A1AA",
   textMuted: "#71717A",
-  accent: "#3B82F6",
-  accentMuted: "#2563EB",
+  accent: "#2DD4BF",
+  accentMuted: "#14B8A6",
 };
 
 type SliderConfig = {
@@ -235,7 +235,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   valueBadge: {
-    backgroundColor: "rgba(59, 130, 246, 0.15)",
+    backgroundColor: "rgba(45, 212, 191, 0.15)",
     paddingHorizontal: 12,
     paddingVertical: 6,
     borderRadius: 8,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:ci": "jest --passWithNoTests"
   },
   "dependencies": {
+    "@expo/vector-icons": "^15.1.1",
     "@react-native-async-storage/async-storage": "^3.0.1",
     "@react-native-community/slider": "^5.1.2",
     "audio-encoder": "file:./modules/audio-encoder",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@expo/vector-icons':
+        specifier: ^15.1.1
+        version: 15.1.1(expo-font@55.0.4)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       '@react-native-async-storage/async-storage':
         specifier: ^3.0.1
         version: 3.0.1(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)

--- a/src/components/AudioLevelMeter.tsx
+++ b/src/components/AudioLevelMeter.tsx
@@ -1,8 +1,8 @@
-import { View, Text, StyleSheet } from 'react-native';
-import Svg, { Rect, Path, Line } from 'react-native-svg';
-import type { Phase } from '../hooks/types';
-import { dbToNormalized } from '../lib/audio';
-import { LEVEL_HISTORY_SIZE } from '../constants/audio';
+import { View, Text, StyleSheet } from "react-native";
+import Svg, { Rect, Path, Line } from "react-native-svg";
+import type { Phase } from "../hooks/types";
+import { dbToNormalized } from "../lib/audio";
+import { LEVEL_HISTORY_SIZE } from "../constants/audio";
 
 export const BAR_WIDTH = 4;
 const BAR_GAP = 3;
@@ -12,21 +12,21 @@ const CONTENT_WIDTH =
   LEVEL_HISTORY_SIZE * BAR_WIDTH + (LEVEL_HISTORY_SIZE - 1) * BAR_GAP;
 
 const PHASE_COLOR: Record<Phase, string> = {
-  idle: '#3B82F6',
-  recording: '#EF4444',
-  playing: '#22C55E',
-  paused: '#52525B',
+  idle: "#2DD4BF",
+  recording: "#F87171",
+  playing: "#5EEAD4",
+  paused: "#52525B",
 };
 
 const PHASE_GLOW: Record<Phase, string> = {
-  idle: 'rgba(59, 130, 246, 0.4)',
-  recording: 'rgba(239, 68, 68, 0.4)',
-  playing: 'rgba(34, 197, 94, 0.4)',
-  paused: 'rgba(82, 82, 91, 0.2)',
+  idle: "rgba(45, 212, 191, 0.4)",
+  recording: "rgba(248, 113, 113, 0.4)",
+  playing: "rgba(94, 234, 212, 0.4)",
+  paused: "rgba(82, 82, 91, 0.2)",
 };
 
-const VOICE_THRESHOLD_COLOR = 'rgba(239, 68, 68, 0.6)';
-const SILENCE_THRESHOLD_COLOR = 'rgba(251, 191, 36, 0.6)';
+const VOICE_THRESHOLD_COLOR = "rgba(248, 113, 113, 0.6)";
+const SILENCE_THRESHOLD_COLOR = "rgba(251, 191, 36, 0.6)";
 
 type Props = {
   history: number[];
@@ -36,11 +36,17 @@ type Props = {
   silenceThresholdDb: number;
 };
 
-export function AudioLevelMeter({ history, phase, currentDb, voiceThresholdDb, silenceThresholdDb }: Props) {
+export function AudioLevelMeter({
+  history,
+  phase,
+  currentDb,
+  voiceThresholdDb,
+  silenceThresholdDb,
+}: Props) {
   const color = PHASE_COLOR[phase];
   const glowColor = PHASE_GLOW[phase];
-  const isPaused = phase === 'paused';
-  const showGuides = phase === 'idle' || phase === 'recording';
+  const isPaused = phase === "paused";
+  const showGuides = phase === "idle" || phase === "recording";
 
   const voiceNormalized = dbToNormalized(voiceThresholdDb);
   const silenceNormalized = dbToNormalized(silenceThresholdDb);
@@ -58,11 +64,6 @@ export function AudioLevelMeter({ history, phase, currentDb, voiceThresholdDb, s
         height={MAX_HEIGHT}
         viewBox={`0 0 ${CONTENT_WIDTH} ${MAX_HEIGHT}`}
       >
-        <Path
-          d={`M40,${MAX_HEIGHT * 0.4} h${CONTENT_WIDTH - 80} a40,40 0 0 1 40,40 v${MAX_HEIGHT * 0.6 - 40} h-${CONTENT_WIDTH} v-${MAX_HEIGHT * 0.6 - 40} a40,40 0 0 1 40,-40 z`}
-          fill={glowColor}
-        />
-
         {showGuides && (
           <>
             <Line
@@ -110,9 +111,7 @@ export function AudioLevelMeter({ history, phase, currentDb, voiceThresholdDb, s
 
       {showGuides && currentDb !== null && (
         <View style={styles.dbLabelContainer}>
-          <Text style={styles.dbLabel}>
-            {Math.round(currentDb)} dB
-          </Text>
+          <Text style={styles.dbLabel}>{Math.round(currentDb)} dB</Text>
         </View>
       )}
     </View>
@@ -123,18 +122,18 @@ const styles = StyleSheet.create({
   container: {
     height: MAX_HEIGHT,
     paddingHorizontal: 16,
-    position: 'relative',
-    alignSelf: 'stretch',
+    position: "relative",
+    alignSelf: "stretch",
   },
   dbLabelContainer: {
-    position: 'absolute',
+    position: "absolute",
     top: -20,
     right: 16,
   },
   dbLabel: {
     fontSize: 12,
-    fontWeight: '600',
-    color: '#A1A1AA',
-    fontVariant: ['tabular-nums'],
+    fontWeight: "600",
+    color: "#A1A1AA",
+    fontVariant: ["tabular-nums"],
   },
 });

--- a/src/components/PhaseDisplay.tsx
+++ b/src/components/PhaseDisplay.tsx
@@ -11,16 +11,16 @@ const PHASE_I18N_KEY: Record<Phase, string> = {
 };
 
 const PHASE_COLOR: Record<Phase, string> = {
-  idle: '#3B82F6',
-  recording: '#EF4444',
-  playing: '#22C55E',
+  idle: '#2DD4BF',
+  recording: '#F87171',
+  playing: '#5EEAD4',
   paused: '#71717A',
 };
 
 const PHASE_BG: Record<Phase, string> = {
-  idle: 'rgba(59, 130, 246, 0.15)',
-  recording: 'rgba(239, 68, 68, 0.15)',
-  playing: 'rgba(34, 197, 94, 0.15)',
+  idle: 'rgba(45, 212, 191, 0.15)',
+  recording: 'rgba(248, 113, 113, 0.15)',
+  playing: 'rgba(94, 234, 212, 0.15)',
   paused: 'rgba(113, 113, 122, 0.15)',
 };
 

--- a/src/components/RecordingItem.tsx
+++ b/src/components/RecordingItem.tsx
@@ -14,10 +14,10 @@ const colors = {
   textPrimary: '#FAFAFA',
   textSecondary: '#A1A1AA',
   textMuted: '#71717A',
-  accent: '#3B82F6',
-  accentLight: 'rgba(59, 130, 246, 0.15)',
-  playing: '#22C55E',
-  playingLight: 'rgba(34, 197, 94, 0.15)',
+  accent: '#2DD4BF',
+  accentLight: 'rgba(45, 212, 191, 0.15)',
+  playing: '#5EEAD4',
+  playingLight: 'rgba(94, 234, 212, 0.15)',
   danger: '#EF4444',
 };
 

--- a/src/components/RecordingsList.tsx
+++ b/src/components/RecordingsList.tsx
@@ -11,7 +11,7 @@ const colors = {
   surfaceElevated: '#1C1C1F',
   border: '#2A2A2E',
   textMuted: '#71717A',
-  accent: '#3B82F6',
+  accent: '#2DD4BF',
 };
 
 type Props = {

--- a/src/screens/VoiceMirrorScreen.tsx
+++ b/src/screens/VoiceMirrorScreen.tsx
@@ -2,6 +2,7 @@ import { View, Text, StyleSheet, SafeAreaView, Pressable } from "react-native";
 import { useRef, useCallback } from "react";
 import { useRouter } from "expo-router";
 import { useTranslation } from "react-i18next";
+import { AntDesign } from "@expo/vector-icons";
 import { useVoiceMirror } from "../hooks/useVoiceMirror";
 import { useRecordings } from "../hooks/useRecordings";
 import { AudioLevelMeter } from "../components/AudioLevelMeter";
@@ -23,10 +24,10 @@ const colors = {
   textPrimary: "#FAFAFA",
   textSecondary: "#A1A1AA",
   textMuted: "#71717A",
-  accent: "#3B82F6",
-  accentHover: "#2563EB",
-  recording: "#EF4444",
-  playing: "#22C55E",
+  accent: "#2DD4BF",
+  accentHover: "#14B8A6",
+  recording: "#F87171",
+  playing: "#5EEAD4",
   paused: "#71717A",
 };
 
@@ -95,6 +96,14 @@ function VoiceMirrorContent() {
   const isPaused = phase === "paused";
   const isRecording = phase === "recording";
 
+  const stateColor = isPaused
+    ? colors.paused
+    : isRecording
+    ? colors.recording
+    : isListPlaying
+    ? colors.playing
+    : colors.accent;
+
   if (permissionDenied) {
     return (
       <SafeAreaView style={styles.root}>
@@ -138,14 +147,14 @@ function VoiceMirrorContent() {
           ]}
         >
           <View style={styles.settingsIconContainer}>
-            <Text style={styles.settingsIcon}>&#x2699;</Text>
+            <AntDesign name="setting" size={20} color={colors.textSecondary} />
           </View>
         </Pressable>
       </View>
       
-      <View style={styles.monitorCard}>
+      <View style={[styles.monitorCard, { borderColor: stateColor }]}>
         <PhaseDisplay phase={meterPhase} />
-        <View style={styles.meterContainer}>
+        <View style={[styles.waveformBox, { borderColor: `${stateColor}33` }]}>
           <AudioLevelMeter
             history={activeLevelHistory}
             phase={meterPhase}
@@ -168,15 +177,11 @@ function VoiceMirrorContent() {
           onPress={togglePause}
           style={({ pressed }) => [
             styles.pauseButton,
-            isPaused && styles.pauseButtonActive,
-            isRecording && styles.pauseButtonRecording,
+            { borderColor: stateColor },
             pressed && styles.pauseButtonPressed,
           ]}
         >
-          <Text style={[
-            styles.pauseButtonLabel,
-            isPaused && styles.pauseButtonLabelActive,
-          ]}>
+          <Text style={[styles.pauseButtonLabel, { color: stateColor }]}>
             {isPaused ? t('main.button_resume') : t('main.button_pause')}
           </Text>
         </Pressable>
@@ -244,10 +249,6 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: colors.border,
   },
-  settingsIcon: {
-    fontSize: 20,
-    color: colors.textSecondary,
-  },
   center: {
     flex: 1,
     alignItems: "center",
@@ -268,18 +269,23 @@ const styles = StyleSheet.create({
     alignItems: "center",
     marginHorizontal: 20,
     marginTop: 8,
-    paddingHorizontal: 24,
-    paddingVertical: 32,
-    gap: 24,
+    paddingHorizontal: 20,
+    paddingVertical: 28,
+    gap: 20,
     backgroundColor: colors.surface,
     borderRadius: 20,
     borderWidth: 1,
     borderColor: colors.border,
   },
-  meterContainer: {
+  waveformBox: {
     width: "100%",
     alignItems: "center",
-    paddingVertical: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 4,
+    marginTop: 8,
+    backgroundColor: "rgba(255, 255, 255, 0.02)",
+    borderRadius: 16,
+    borderWidth: 1,
   },
   hint: {
     color: colors.textMuted,
@@ -288,34 +294,22 @@ const styles = StyleSheet.create({
     fontWeight: "500",
   },
   pauseButton: {
-    paddingHorizontal: 40,
-    paddingVertical: 16,
-    borderRadius: 14,
-    backgroundColor: colors.surfaceElevated,
+    paddingHorizontal: 48,
+    paddingVertical: 14,
+    borderRadius: 999,
+    backgroundColor: "transparent",
     borderWidth: 1,
-    borderColor: colors.border,
-    minWidth: 160,
+    minWidth: 180,
     alignItems: "center",
   },
-  pauseButtonActive: {
-    backgroundColor: colors.accent,
-    borderColor: colors.accent,
-  },
-  pauseButtonRecording: {
-    borderColor: colors.recording,
-  },
   pauseButtonPressed: {
-    opacity: 0.8,
+    opacity: 0.7,
     transform: [{ scale: 0.98 }],
   },
   pauseButtonLabel: {
     fontSize: 16,
     fontWeight: "600",
-    color: colors.textSecondary,
     letterSpacing: 0.3,
-  },
-  pauseButtonLabelActive: {
-    color: colors.textPrimary,
   },
   recordingsSection: {
     flex: 1,
@@ -362,7 +356,7 @@ const styles = StyleSheet.create({
     width: 48,
     height: 48,
     borderRadius: 24,
-    backgroundColor: "rgba(239, 68, 68, 0.15)",
+    backgroundColor: "rgba(248, 113, 113, 0.15)",
     alignItems: "center",
     justifyContent: "center",
   },
@@ -372,7 +366,7 @@ const styles = StyleSheet.create({
     color: colors.recording,
   },
   errorBadge: {
-    backgroundColor: "rgba(239, 68, 68, 0.15)",
+    backgroundColor: "rgba(248, 113, 113, 0.15)",
     paddingHorizontal: 14,
     paddingVertical: 8,
     borderRadius: 10,


### PR DESCRIPTION
## Summary
- Adopt the teal/coral/light-teal state palette from the new designer mockup across screens and components (listening, recording, playing).
- Refresh the main screen: monitor card and pause button now use state-colored outlines, and the waveform sits inside a tinted inner panel.
- Replace the gear glyph with AntDesign's `setting` icon via `@expo/vector-icons`.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:ci` (113/113)
- [x] Manual smoke on device: verify listening/recording/playing/paused colors and the settings icon render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)