### PR TITLE
feat: add explicit Sentry exception/message capturing and breadcrumbs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ yarn-error.*
 
 # Claude code workflow
 research.md
+.env.local

--- a/app.json
+++ b/app.json
@@ -46,13 +46,26 @@
         "react-native-audio-api",
         {
           "iosMicrophonePermission": "VoiceMirror records your voice so you can immediately hear yourself back.",
-          "androidPermissions": ["android.permission.RECORD_AUDIO"]
+          "androidPermissions": [
+            "android.permission.RECORD_AUDIO"
+          ]
         }
       ],
       [
         "expo-localization",
         {
-          "supportedLocales": ["en", "ja"]
+          "supportedLocales": [
+            "en",
+            "ja"
+          ]
+        }
+      ],
+      [
+        "@sentry/react-native/expo",
+        {
+          "url": "https://sentry.io/",
+          "project": "voice-mirror",
+          "organization": "tai2net"
         }
       ]
     ]

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,6 +16,29 @@ import {
   E2EAudioRecordingService,
   type E2EConnectionStatus,
 } from "../src/services/E2EAudioRecordingService";
+import * as Sentry from "@sentry/react-native";
+
+Sentry.init({
+  dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
+
+  // Adds more context data to events (IP address, cookies, user, etc.)
+  // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
+  sendDefaultPii: true,
+
+  // Enable Logs
+  enableLogs: true,
+
+  // Configure Session Replay
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1,
+  integrations: [
+    Sentry.mobileReplayIntegration(),
+    Sentry.feedbackIntegration(),
+  ],
+
+  // uncomment the line below to enable Spotlight (https://spotlightjs.com)
+  // spotlight: __DEV__,
+});
 
 // Design tokens
 const colors = {
@@ -99,7 +122,7 @@ function RootStack() {
         },
         headerTintColor: colors.textPrimary,
         headerTitleStyle: {
-          fontWeight: '600',
+          fontWeight: "600",
         },
         contentStyle: {
           backgroundColor: colors.background,
@@ -112,8 +135,8 @@ function RootStack() {
       />
       <Stack.Screen
         name="settings"
-        options={{ 
-          title: t("settings.title"), 
+        options={{
+          title: t("settings.title"),
           presentation: "card",
           headerShadowVisible: false,
         }}
@@ -122,7 +145,7 @@ function RootStack() {
   );
 }
 
-export default function RootLayout() {
+export default Sentry.wrap(function RootLayout() {
   return (
     <GestureHandlerRootView style={styles.root}>
       <I18nProvider>
@@ -136,7 +159,7 @@ export default function RootLayout() {
       </I18nProvider>
     </GestureHandlerRootView>
   );
-}
+});
 
 const styles = StyleSheet.create({
   root: {

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,5 @@
+const { getSentryExpoConfig } = require("@sentry/react-native/metro");
+
+const config = getSentryExpoConfig(__dirname);
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@expo/vector-icons": "^15.1.1",
     "@react-native-async-storage/async-storage": "^3.0.1",
     "@react-native-community/slider": "^5.1.2",
+    "@sentry/react-native": "^8.7.0",
     "audio-encoder": "file:./modules/audio-encoder",
     "expo": "~55.0.5",
     "expo-dev-client": "^55.0.11",

--- a/plans/20260414-sentry-explicit-capturing.md
+++ b/plans/20260414-sentry-explicit-capturing.md
@@ -1,0 +1,531 @@
+# Add Explicit Sentry Exception and Message Capturing
+
+## Goal
+
+Enhance the Sentry integration beyond automatic unhandled-exception capture by adding explicit `captureException`, `captureMessage`, and `addBreadcrumb` calls at every known error/warning site in the application. Currently, Sentry only captures unhandled JS exceptions and native crashes. All caught exceptions in the codebase are silently swallowed with `console.error` -- invisible to Sentry. This means production failures in audio encoding, decoding, file I/O, and settings persistence go unnoticed unless a user explicitly reports them.
+
+After this change, every caught error and significant application event will be reported to Sentry with structured context (file paths, phases, sample rates, durations), making it possible to diagnose production issues from the Sentry dashboard.
+
+## Architecture / Approach
+
+### Strategy
+
+1. **Create a thin Sentry helper module** (`src/lib/sentryHelpers.ts`) that wraps `Sentry.captureException`, `Sentry.captureMessage`, and `Sentry.addBreadcrumb` with app-specific context. This keeps the Sentry import centralized and makes it easy to no-op in tests (the module can be mocked).
+
+2. **Add `captureException` at every existing `catch` block** that currently only does `console.error`. These represent real failures that should appear as Sentry issues. Each call includes structured context about what operation failed and with what parameters.
+
+3. **Add `captureMessage` for notable non-exception error conditions** -- situations where no exception is thrown but something went wrong (e.g., encoder returned duration 0, encoder skipped due to prior failure).
+
+4. **Add breadcrumbs at key state transitions** in the voice mirror lifecycle (permission granted, recording started, recording stopped, playback started, pause/resume). These appear in the Sentry event timeline and provide critical context for understanding what the user was doing before an error occurred.
+
+5. **Keep `console.error`/`console.warn` calls intact** alongside the Sentry calls. They remain useful for local development debugging where Sentry may not be configured.
+
+### Why a helper module
+
+- Avoids importing `* as Sentry from '@sentry/react-native'` in every file
+- Provides type-safe context parameters for common operations
+- Can be trivially replaced with no-ops in unit tests (no need to mock the Sentry SDK)
+- Single place to adjust severity levels, fingerprinting, or tags later
+
+### Scope of changes
+
+The changes are purely additive: no existing logic is altered. Every modification is adding a Sentry call next to an existing `console.error`, `console.warn`, or at a state transition boundary.
+
+## File Changes
+
+### 1. New file: `src/lib/sentryHelpers.ts`
+
+A lightweight wrapper that provides typed capture functions:
+
+```typescript
+import * as Sentry from '@sentry/react-native';
+
+/**
+ * Capture a caught exception with structured context.
+ * Use this at every catch block that handles a real error.
+ */
+export function captureException(
+  error: unknown,
+  context: Record<string, unknown>,
+): void {
+  Sentry.withScope((scope) => {
+    scope.setContext('operation', context);
+    Sentry.captureException(error);
+  });
+}
+
+/**
+ * Capture a non-exception error message with structured context.
+ * Use for situations where no exception was thrown but something went wrong.
+ */
+export function captureMessage(
+  message: string,
+  context: Record<string, unknown>,
+  level: Sentry.SeverityLevel = 'error',
+): void {
+  Sentry.withScope((scope) => {
+    scope.setContext('operation', context);
+    scope.setLevel(level);
+    Sentry.captureMessage(message);
+  });
+}
+
+/**
+ * Record a breadcrumb for a significant app event.
+ * Breadcrumbs appear in the timeline of the next Sentry error event.
+ */
+export function addBreadcrumb(
+  category: string,
+  message: string,
+  data?: Record<string, unknown>,
+  level: Sentry.SeverityLevel = 'info',
+): void {
+  Sentry.addBreadcrumb({
+    category,
+    message,
+    data,
+    level,
+  });
+}
+```
+
+### 2. Modify: `src/hooks/useVoiceMirror.ts`
+
+Add Sentry captures at every existing `console.error` site and breadcrumbs at state transitions.
+
+**Add import:**
+
+```typescript
+import { captureException, captureMessage, addBreadcrumb } from '../lib/sentryHelpers';
+```
+
+**In `beginEncoding()` -- startEncoding failure (line ~88-92):**
+
+```typescript
+    } catch (e) {
+      console.error('[AudioEncoder] startEncoding failed:', e);
+      captureException(e, {
+        operation: 'AudioEncoder.startEncoding',
+        filePath,
+        sampleRate: context.sampleRate,
+      });
+      return;
+    }
+```
+
+**In `beginEncoding()` -- encodeChunk failure during catchup (line ~107-111):**
+
+```typescript
+      } catch (e) {
+        console.error('[AudioEncoder] encodeChunk failed:', e);
+        captureException(e, {
+          operation: 'AudioEncoder.encodeChunk',
+          phase: 'catchup',
+          filePath,
+        });
+        encoderFailedRef.current = true;
+      }
+```
+
+**In `startMonitoring()` -- encodeChunk failure during streaming (line ~202-206):**
+
+```typescript
+          } catch (e) {
+            console.error('[AudioEncoder] encodeChunk failed:', e);
+            captureException(e, {
+              operation: 'AudioEncoder.encodeChunk',
+              phase: 'streaming',
+            });
+            encoderFailedRef.current = true;
+          }
+```
+
+**In `stopAndPlay()` -- stopEncoding returned 0 (line ~245-246):**
+
+```typescript
+        if (durationMs === 0) {
+          console.error(`[AudioEncoder] stopEncoding returned 0 for ${filePath}`);
+          captureMessage('AudioEncoder stopEncoding returned duration 0', {
+            operation: 'AudioEncoder.stopEncoding',
+            filePath,
+            sampleRate: context.sampleRate,
+          });
+        }
+```
+
+**In `stopAndPlay()` -- stopEncoding threw (line ~248-249):**
+
+```typescript
+      } catch (e) {
+        console.error(`[AudioEncoder] stopEncoding threw for ${filePath}:`, e);
+        captureException(e, {
+          operation: 'AudioEncoder.stopEncoding',
+          filePath,
+          sampleRate: context.sampleRate,
+        });
+      }
+```
+
+**In `stopAndPlay()` -- skipped stopEncoding due to prior chunk error (line ~251-252):**
+
+```typescript
+    } else if (filePath && encoderFailedRef.current) {
+      console.error(`[AudioEncoder] skipped stopEncoding due to prior chunk error: ${filePath}`);
+      captureMessage('AudioEncoder skipped stopEncoding due to prior chunk error', {
+        operation: 'AudioEncoder.stopEncoding',
+        filePath,
+        reason: 'prior_chunk_error',
+      }, 'warning');
+    }
+```
+
+**In `pauseMonitoring()` -- stopEncoding failed during pause cleanup (line ~314-316):**
+
+```typescript
+        } catch (e) {
+          console.error('[AudioEncoder] stopEncoding failed during pause cleanup:', e);
+          captureException(e, {
+            operation: 'AudioEncoder.stopEncoding',
+            phase: 'pause_cleanup',
+            filePath,
+          });
+        }
+```
+
+**Breadcrumbs for state transitions -- add at the appropriate locations:**
+
+In `startMonitoring()`, after the recorder starts (after line ~181):
+```typescript
+    addBreadcrumb('voicemirror', 'Monitoring started', {
+      sampleRate: context.sampleRate,
+    });
+```
+
+In `tickStateMachine()`, when transitioning to recording (after `setPhase('recording')` around line ~132):
+```typescript
+          addBreadcrumb('voicemirror', 'Recording started', {
+            voiceStartFrame: voiceStartFrameRef.current,
+          });
+```
+
+In `tickStateMachine()`, when transitioning to playing (after `setPhase('playing')` around lines ~143, ~155):
+```typescript
+          addBreadcrumb('voicemirror', 'Recording stopped, playing back');
+```
+
+In `pauseMonitoring()`, at the start:
+```typescript
+    addBreadcrumb('voicemirror', 'Monitoring paused');
+```
+
+In `resumeMonitoring()`, at the start:
+```typescript
+    addBreadcrumb('voicemirror', 'Monitoring resumed');
+```
+
+### 3. Modify: `src/hooks/useRecordings.ts`
+
+**Add import:**
+
+```typescript
+import { captureException, addBreadcrumb } from '../lib/sentryHelpers';
+```
+
+**In `togglePlay()` -- decodeAudioData failure (line ~131-133):**
+
+```typescript
+    } catch (e) {
+      console.error('[useRecordings] decodeAudioData failed:', e);
+      captureException(e, {
+        operation: 'AudioDecoder.decodeAudioData',
+        filePath: recording.filePath,
+        recordingId: recording.id,
+        sampleRate: audioContext.sampleRate,
+      });
+      isDecodingRef.current = false;
+      setPlayState(null);
+      await options.onDidStop();
+      return;
+    }
+```
+
+**Breadcrumb for list playback start -- after `source.start(0)` (line ~151):**
+
+```typescript
+    addBreadcrumb('recordings', 'List playback started', {
+      recordingId: recording.id,
+      durationMs: recording.durationMs,
+    });
+```
+
+### 4. Modify: `src/lib/recordings.ts`
+
+**Add import:**
+
+```typescript
+import { captureException, captureMessage } from './sentryHelpers';
+```
+
+**In `loadRecordings()` -- stale entry warning (line ~31-34):**
+
+```typescript
+    } else {
+      console.warn(
+        `[recordings] Removing stale entry: ${recording.filePath} (file not found on disk)`,
+      );
+      captureMessage('Stale recording entry removed (file missing)', {
+        operation: 'loadRecordings',
+        filePath: recording.filePath,
+        recordingId: recording.id,
+      }, 'warning');
+    }
+```
+
+**In `loadRecordings()` -- orphaned file warning (line ~46-48):**
+
+```typescript
+      console.warn(
+        `[recordings] Deleting orphaned file: ${entry.uri} (not in index)`,
+      );
+      captureMessage('Orphaned recording file deleted', {
+        operation: 'loadRecordings',
+        fileUri: entry.uri,
+      }, 'warning');
+```
+
+**In `loadRecordings()` -- failed to delete orphaned file (line ~51-53):**
+
+```typescript
+      } catch (e) {
+        console.error(`[recordings] Failed to delete orphaned file: ${entry.uri}`, e);
+        captureException(e, {
+          operation: 'deleteOrphanedFile',
+          fileUri: entry.uri,
+        });
+      }
+```
+
+### 5. Modify: `src/context/SettingsProvider.tsx`
+
+Settings persistence failures are currently completely silent (the `void` promise is fire-and-forget). Add error handling with Sentry capture.
+
+**Add import:**
+
+```typescript
+import { captureException } from '../lib/sentryHelpers';
+```
+
+**In `updateSetting` -- wrap the repository.save call (line ~38):**
+
+Change:
+```typescript
+      void repository.save(key, value);
+```
+
+To:
+```typescript
+      repository.save(key, value).catch((e) => {
+        captureException(e, {
+          operation: 'SettingsRepository.save',
+          key,
+          value,
+        });
+      });
+```
+
+**In `resetSettings` -- wrap the repository.resetAll call (line ~44):**
+
+Change:
+```typescript
+    void repository.resetAll();
+```
+
+To:
+```typescript
+    repository.resetAll().catch((e) => {
+      captureException(e, {
+        operation: 'SettingsRepository.resetAll',
+      });
+    });
+```
+
+**In the `useEffect` -- wrap the repository.load call (line ~28-30):**
+
+Change:
+```typescript
+    repository.load().then((s) => {
+      setSettings(s);
+      setLoaded(true);
+    });
+```
+
+To:
+```typescript
+    repository.load().then((s) => {
+      setSettings(s);
+      setLoaded(true);
+    }).catch((e) => {
+      captureException(e, {
+        operation: 'SettingsRepository.load',
+      });
+      setLoaded(true); // proceed with defaults
+    });
+```
+
+### 6. Modify: `src/context/AudioContextProvider.tsx`
+
+The `AudioContext` constructor could theoretically throw. Add a safety net.
+
+**Add import:**
+
+```typescript
+import { captureException, addBreadcrumb } from '../lib/sentryHelpers';
+```
+
+**Wrap the AudioContext creation (lines ~10-12):**
+
+Change:
+```typescript
+    const context = new AudioContext();
+    setCtx(context);
+    return () => { void context.close(); };
+```
+
+To:
+```typescript
+    let context: AudioContext;
+    try {
+      context = new AudioContext();
+    } catch (e) {
+      captureException(e, {
+        operation: 'AudioContext.create',
+      });
+      return;
+    }
+    addBreadcrumb('audio', 'AudioContext created', {
+      sampleRate: context.sampleRate,
+    });
+    setCtx(context);
+    return () => { void context.close(); };
+```
+
+### 7. Modify: `src/hooks/useVoiceMirror.ts` (additional: permission breadcrumb)
+
+In the `useEffect` that handles permissions (line ~60-73), add breadcrumbs:
+
+After permission granted (after `setHasPermission(true)`, line ~66):
+```typescript
+      addBreadcrumb('voicemirror', 'Microphone permission granted');
+```
+
+When permission denied (after `setPermissionDenied(true)`, line ~64):
+```typescript
+        addBreadcrumb('voicemirror', 'Microphone permission denied', undefined, 'warning');
+```
+
+## Summary of All Files Modified
+
+| File | Changes |
+|---|---|
+| `src/lib/sentryHelpers.ts` | **New file** -- centralized `captureException`, `captureMessage`, `addBreadcrumb` wrappers |
+| `src/hooks/useVoiceMirror.ts` | 6 `captureException` calls, 2 `captureMessage` calls, 5 breadcrumbs |
+| `src/hooks/useRecordings.ts` | 1 `captureException` call, 1 breadcrumb |
+| `src/lib/recordings.ts` | 1 `captureException` call, 2 `captureMessage` calls |
+| `src/context/SettingsProvider.tsx` | 3 `captureException` calls (load, save, resetAll) |
+| `src/context/AudioContextProvider.tsx` | 1 `captureException` call, 1 breadcrumb |
+
+## Considerations and Trade-offs
+
+### Event volume and quotas
+
+Adding explicit `captureException` and `captureMessage` calls increases the number of events sent to Sentry. In pathological cases (e.g., the encoder repeatedly failing on every audio chunk during a long recording), this could generate many events quickly. Mitigation: Sentry's built-in rate limiting and deduplication handles this -- the SDK has a `maxQueueSize` of 30 and the server side deduplicates identical issues. The `encodeChunk` failure during streaming also sets `encoderFailedRef.current = true`, which prevents further chunks from being attempted, so in practice only one event is sent per recording attempt.
+
+### Warning-level messages for non-critical conditions
+
+Stale recording entries and orphaned files are captured at `warning` level, not `error`. These represent data consistency issues that self-heal (the app fixes them automatically). They are worth knowing about for patterns (e.g., "are orphaned files increasing?") but should not trigger alerts.
+
+### No changes to the Sentry `init` configuration
+
+The existing configuration with `replaysOnErrorSampleRate: 1` means every error event will include a session replay, which is valuable for debugging. No changes needed to the init call.
+
+### Test impact
+
+The new `src/lib/sentryHelpers.ts` module imports `@sentry/react-native`, which is a native module. In unit tests, this module will need to be mocked. The simplest approach is a Jest module mock:
+
+```typescript
+// In jest.setup.js or a __mocks__ file
+jest.mock('../src/lib/sentryHelpers', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+  addBreadcrumb: jest.fn(),
+}));
+```
+
+Since the helper functions are side-effect-only (they return `void`), mocking them as no-ops has zero impact on test assertions. No existing tests need logic changes.
+
+### Why not inject Sentry as a service dependency
+
+The project architecture injects services (AudioRecordingService, AudioEncoderService, etc.) to enable test stubbing. Sentry capturing is a cross-cutting observability concern, not a service the application logic depends on. Making it injectable would add complexity (passing through context, adding to `Services` type) without benefit -- the mock at module level is sufficient and simpler. If a future need arises to verify that specific errors are captured in tests, the mock can be changed to a spy.
+
+### The sentryHelpers module does not wrap `Sentry.init` or `Sentry.wrap`
+
+Those remain in `app/_layout.tsx` where they must run at app startup before any component renders. Only the per-event capturing APIs are centralized.
+
+## Todo
+
+### Phase 1: Create the Sentry helper module
+
+- [x] Create `src/lib/sentryHelpers.ts` with `captureException` wrapper (accepts `error: unknown` and `context: Record<string, unknown>`, uses `Sentry.withScope`)
+- [x] Add `captureMessage` wrapper (accepts `message`, `context`, optional `level` defaulting to `'error'`)
+- [x] Add `addBreadcrumb` wrapper (accepts `category`, `message`, optional `data`, optional `level` defaulting to `'info'`)
+
+### Phase 2: Add Sentry captures to `src/hooks/useVoiceMirror.ts`
+
+- [x] Add import of `captureException`, `captureMessage`, `addBreadcrumb` from `../lib/sentryHelpers`
+- [x] Add `captureException` in `beginEncoding()` catch block for `startEncoding` failure (with `operation`, `filePath`, `sampleRate` context)
+- [x] Add `captureException` in `beginEncoding()` catch block for `encodeChunk` failure during catchup (with `operation`, `phase: 'catchup'`, `filePath` context)
+- [x] Add `captureException` in `startMonitoring()` catch block for `encodeChunk` failure during streaming (with `operation`, `phase: 'streaming'` context)
+- [x] Add `captureMessage` in `stopAndPlay()` when `stopEncoding` returns duration 0 (with `operation`, `filePath`, `sampleRate` context)
+- [x] Add `captureException` in `stopAndPlay()` catch block when `stopEncoding` throws (with `operation`, `filePath`, `sampleRate` context)
+- [x] Add `captureMessage` in `stopAndPlay()` when stopEncoding is skipped due to prior chunk error (with `operation`, `filePath`, `reason` context, level `'warning'`)
+- [x] Add `captureException` in `pauseMonitoring()` catch block for `stopEncoding` failure during pause cleanup (with `operation`, `phase: 'pause_cleanup'`, `filePath` context)
+- [x] Add `addBreadcrumb` in `startMonitoring()` after recorder starts ("Monitoring started" with `sampleRate`)
+- [x] Add `addBreadcrumb` in `tickStateMachine()` when transitioning to recording ("Recording started" with `voiceStartFrame`)
+- [x] Add `addBreadcrumb` in `tickStateMachine()` when transitioning to playing ("Recording stopped, playing back")
+- [x] Add `addBreadcrumb` in `pauseMonitoring()` at start ("Monitoring paused")
+- [x] Add `addBreadcrumb` in `resumeMonitoring()` at start ("Monitoring resumed")
+- [x] Add `addBreadcrumb` in permission `useEffect` when permission granted ("Microphone permission granted")
+- [x] Add `addBreadcrumb` in permission `useEffect` when permission denied ("Microphone permission denied", level `'warning'`)
+
+### Phase 3: Add Sentry captures to `src/hooks/useRecordings.ts`
+
+- [x] Add import of `captureException`, `addBreadcrumb` from `../lib/sentryHelpers`
+- [x] Add `captureException` in `togglePlay()` catch block for `decodeAudioData` failure (with `operation`, `filePath`, `recordingId`, `sampleRate` context)
+- [x] Add `addBreadcrumb` after `source.start(0)` for list playback start (with `recordingId`, `durationMs`)
+
+### Phase 4: Add Sentry captures to `src/lib/recordings.ts`
+
+- [x] Add import of `captureException`, `captureMessage` from `./sentryHelpers`
+- [x] Add `captureMessage` in `loadRecordings()` for stale entry removal warning (with `operation`, `filePath`, `recordingId` context, level `'warning'`)
+- [x] Add `captureMessage` in `loadRecordings()` for orphaned file deletion warning (with `operation`, `fileUri` context, level `'warning'`)
+- [x] Add `captureException` in `loadRecordings()` catch block for failed orphaned file deletion (with `operation`, `fileUri` context)
+
+### Phase 5: Add Sentry captures to `src/context/SettingsProvider.tsx`
+
+- [x] Add import of `captureException` from `../lib/sentryHelpers`
+- [x] Change `void repository.save(key, value)` in `updateSetting` to use `.catch()` with `captureException` (with `operation`, `key`, `value` context)
+- [x] Change `void repository.resetAll()` in `resetSettings` to use `.catch()` with `captureException` (with `operation` context)
+- [x] Add `.catch()` to `repository.load()` in the `useEffect`, calling `captureException` (with `operation` context) and still calling `setLoaded(true)` to proceed with defaults
+
+### Phase 6: Add Sentry captures to `src/context/AudioContextProvider.tsx`
+
+- [x] Add import of `addBreadcrumb` from `../lib/sentryHelpers`
+- [x] ~~Wrap `new AudioContext()` in try/catch~~ — skipped, constructor without arguments doesn't throw
+- [x] Add `addBreadcrumb` after successful AudioContext creation ("AudioContext created" with `sampleRate`)
+
+### Phase 7: Test setup and verification
+
+- [x] Add `jest.mock('../lib/sentryHelpers')` (or equivalent path) to each test file that imports modules now depending on `sentryHelpers`: `src/hooks/__tests__/useVoiceMirror.test.ts`, `src/hooks/__tests__/useRecordings.test.ts`, `src/lib/__tests__/recordings.test.ts`
+- [x] Run `pnpm typecheck` and fix any type errors
+- [x] Run `pnpm lint` and fix any lint issues
+- [x] Run `pnpm test:ci` and confirm all existing tests pass with the new mocks

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@react-native-community/slider':
         specifier: ^5.1.2
         version: 5.1.2
+      '@sentry/react-native':
+        specifier: ^8.7.0
+        version: 8.7.0(expo@55.0.5)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       audio-encoder:
         specifier: file:./modules/audio-encoder
         version: file:modules/audio-encoder
@@ -1865,6 +1868,107 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sentry-internal/browser-utils@10.47.0':
+    resolution: {integrity: sha512-bVFRAeJWMBcBCvJKIFCMJ1/yQToL4vPGqfmlnDZeypcxkqUDKQ/Y3ziLHXoDL2sx0lagcgU2vH1QhCQ67Aujjw==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@10.47.0':
+    resolution: {integrity: sha512-pdvMmi4dQpX5S/vAAzrhHPIw3T3HjUgDNgUiCBrlp7N9/6zGO2gNPhUnNekP+CjgI/z0rvf49RLqlDenpNrMOg==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay-canvas@10.47.0':
+    resolution: {integrity: sha512-A5OY8friSe6g8WAK4L8IeOPiEd9D3Ps40DzRH5j2f6SUja0t90mKMvHRcRf8zq0d4BkdB+JM7tjOkwxpuv8heA==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@10.47.0':
+    resolution: {integrity: sha512-ScdovxP7hJxgMt70+7hFvwT02GIaIUAxdEM/YPsayZBeCoAukPW8WiwztJfoKtsfPyKJ5A6f0H3PIxTPcA9Row==}
+    engines: {node: '>=18'}
+
+  '@sentry/babel-plugin-component-annotate@5.1.1':
+    resolution: {integrity: sha512-x2wEpBHwsTyTF2rWsLKJlzrRF1TTIGOfX+ngdE+Yd5DBkoS58HwQv824QOviPGQRla4/ypISqAXzjdDPL/zalg==}
+    engines: {node: '>= 18'}
+
+  '@sentry/browser@10.47.0':
+    resolution: {integrity: sha512-rC0agZdxKA5XWfL4VwPOr/rJMogXDqZgnVzr93YWpFn9DMZT/7LzxSJVPIJwRUjx3bFEby3PcTa3YaX7pxm1AA==}
+    engines: {node: '>=18'}
+
+  '@sentry/cli-darwin@3.3.5':
+    resolution: {integrity: sha512-E/SIY6+j2nt6Ri9nMt78sYle3LiF6uZyz4HGmvcEMU6HXjegmAayhy0J10JST+vZTzN6VixD8sUsa5UeJiOPcg==}
+    engines: {node: '>=18'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@3.3.5':
+    resolution: {integrity: sha512-/W7HTk2OFKD0bguTvQR1ue6pkFQWaGiqPafOSIQKyq0aGfbZhBn/Uj+IRefgMZMhJQ29xRz0y/iGRGKE+ef4Vg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@3.3.5':
+    resolution: {integrity: sha512-EGuEIvC2OQyar/vu+jAQEmovTMgxpoxdx5knnzL5dLhIemjEUNqwv/sXq+m/Aj+ThqCMofcTWB2TOZXsTtl0Tw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@3.3.5':
+    resolution: {integrity: sha512-qODMEWLEeUNp3IUlwwISB37EXSo8qgMmHQuLKfxDjpIKw+7NAFfptOloqPrHkLWK3TzFr+Nv643wIKZaYrz28Q==}
+    engines: {node: '>=18'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@3.3.5':
+    resolution: {integrity: sha512-DCz7lQ4PySjQ1WvWOQ/uTdwauRo1D7hSHazxZ+fUAnK/epSPM9qLkjDMlD8uM5CaLoR8+ZTs7N94vV5LZs2QpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@3.3.5':
+    resolution: {integrity: sha512-VMNsHiyZcP8Ft3fcK/1zoO4L66soe1eSfXg2tglFQSc/2MYA5v1Br9B1GtjBwDIc3EmdPtFZhOGLyqIzszMxJw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@3.3.5':
+    resolution: {integrity: sha512-BE6aHOIpsm4jgavsvvXNcSikAr/8NSva3rk1N3BzoOLuX+dcFxBI60K1i2VzB1vsgtivJJo9YySNCi60dBgWTg==}
+    engines: {node: '>=18'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@3.3.5':
+    resolution: {integrity: sha512-MSU+PtBuiLjEbiPFOvxk4CI3TCagwkIg9kvJ+DrI3+pBY0Sga/dOyeWKTIgb01xSVcfjdw0UkpU52VCvzTT9ew==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@3.3.5':
+    resolution: {integrity: sha512-eyLHTj0rpeCsOUX+1ZU8UEWRXy6nXvTXNdhtAt1t6YXan9gSsAexZf28zVmDcYcP8WRbK0D2JMLp7NcaQCQgEA==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
+  '@sentry/core@10.47.0':
+    resolution: {integrity: sha512-nsYRAx3EWezDut+Zl+UwwP07thh9uY7CfSAi2whTdcJl5hu1nSp2z8bba7Vq/MGbNLnazkd3A+GITBEML924JA==}
+    engines: {node: '>=18'}
+
+  '@sentry/react-native@8.7.0':
+    resolution: {integrity: sha512-15c7L/DW+Po2/6jmwEB+9A1F6SEKOjfUsKZ3wW059Qsksk2gkCS0eeOlkYs20L4ucnstDdDtQD846tZsaeGf7Q==}
+    hasBin: true
+    peerDependencies:
+      expo: '>=49.0.0'
+      react: '>=17.0.0'
+      react-native: '>=0.65.0'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+
+  '@sentry/react@10.47.0':
+    resolution: {integrity: sha512-ZtJV6xxF8jUVE9e3YQUG3Do0XapG1GjniyLyqMPgN6cNvs/HaRJODf7m60By+VGqcl5XArEjEPTvx8CdPUXDfA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/types@10.47.0':
+    resolution: {integrity: sha512-WhV/ZO/a+3pU00rjXtb6WeZFZYn0Kz3JTc8Xvp7cx/D+kQJBm6b942TGb32UvnsglALLBxRyIBG+QO2u5r6cXw==}
+    engines: {node: '>=18'}
 
   '@sidvind/better-ajv-errors@4.0.1':
     resolution: {integrity: sha512-6arF1ssKxItxgitPYXafUoLmsVBA6K7m9+ZGj6hLDoBl7nWpJ33EInwQUdHTle2METeWGxgQiqSex20KZRykew==}
@@ -9181,6 +9285,99 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sentry-internal/browser-utils@10.47.0':
+    dependencies:
+      '@sentry/core': 10.47.0
+
+  '@sentry-internal/feedback@10.47.0':
+    dependencies:
+      '@sentry/core': 10.47.0
+
+  '@sentry-internal/replay-canvas@10.47.0':
+    dependencies:
+      '@sentry-internal/replay': 10.47.0
+      '@sentry/core': 10.47.0
+
+  '@sentry-internal/replay@10.47.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.47.0
+      '@sentry/core': 10.47.0
+
+  '@sentry/babel-plugin-component-annotate@5.1.1': {}
+
+  '@sentry/browser@10.47.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.47.0
+      '@sentry-internal/feedback': 10.47.0
+      '@sentry-internal/replay': 10.47.0
+      '@sentry-internal/replay-canvas': 10.47.0
+      '@sentry/core': 10.47.0
+
+  '@sentry/cli-darwin@3.3.5':
+    optional: true
+
+  '@sentry/cli-linux-arm64@3.3.5':
+    optional: true
+
+  '@sentry/cli-linux-arm@3.3.5':
+    optional: true
+
+  '@sentry/cli-linux-i686@3.3.5':
+    optional: true
+
+  '@sentry/cli-linux-x64@3.3.5':
+    optional: true
+
+  '@sentry/cli-win32-arm64@3.3.5':
+    optional: true
+
+  '@sentry/cli-win32-i686@3.3.5':
+    optional: true
+
+  '@sentry/cli-win32-x64@3.3.5':
+    optional: true
+
+  '@sentry/cli@3.3.5':
+    dependencies:
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      undici: 6.24.1
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 3.3.5
+      '@sentry/cli-linux-arm': 3.3.5
+      '@sentry/cli-linux-arm64': 3.3.5
+      '@sentry/cli-linux-i686': 3.3.5
+      '@sentry/cli-linux-x64': 3.3.5
+      '@sentry/cli-win32-arm64': 3.3.5
+      '@sentry/cli-win32-i686': 3.3.5
+      '@sentry/cli-win32-x64': 3.3.5
+
+  '@sentry/core@10.47.0': {}
+
+  '@sentry/react-native@8.7.0(expo@55.0.5)(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@sentry/babel-plugin-component-annotate': 5.1.1
+      '@sentry/browser': 10.47.0
+      '@sentry/cli': 3.3.5
+      '@sentry/core': 10.47.0
+      '@sentry/react': 10.47.0(react@19.2.0)
+      '@sentry/types': 10.47.0
+      react: 19.2.0
+      react-native: 0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
+    optionalDependencies:
+      expo: 55.0.5(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.6)(expo-router@55.0.7)(react-dom@19.2.4(react@19.2.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+
+  '@sentry/react@10.47.0(react@19.2.0)':
+    dependencies:
+      '@sentry/browser': 10.47.0
+      '@sentry/core': 10.47.0
+      react: 19.2.0
+
+  '@sentry/types@10.47.0':
+    dependencies:
+      '@sentry/core': 10.47.0
 
   '@sidvind/better-ajv-errors@4.0.1(ajv@8.18.0)':
     dependencies:

--- a/src/context/AudioContextProvider.tsx
+++ b/src/context/AudioContextProvider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 import { AudioContext } from 'react-native-audio-api';
+import { addBreadcrumb } from '../lib/sentryHelpers';
 
 const Ctx = createContext<AudioContext | null>(null);
 
@@ -9,6 +10,9 @@ export function AudioContextProvider({ children }: { children: React.ReactNode }
   useEffect(() => {
     // Omit sampleRate to use device-native rate and avoid resampling click artifacts
     const context = new AudioContext();
+    addBreadcrumb('audio', 'AudioContext created', {
+      sampleRate: context.sampleRate,
+    });
     setCtx(context);
     return () => { void context.close(); };
   }, []);

--- a/src/context/SettingsProvider.tsx
+++ b/src/context/SettingsProvider.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { type AppSettings, DEFAULT_SETTINGS } from '../types/settings';
 import type { ISettingsRepository } from '../repositories/SettingsRepository';
+import { captureException } from '../lib/sentryHelpers';
 
 type SettingsContextValue = {
   settings: AppSettings;
@@ -28,20 +29,35 @@ export function SettingsProvider({
     repository.load().then((s) => {
       setSettings(s);
       setLoaded(true);
+    }).catch((e) => {
+      captureException(e, {
+        operation: 'SettingsRepository.load',
+      });
+      setLoaded(true);
     });
   }, [repository]);
 
   const updateSetting = useCallback(
     <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => {
       setSettings((prev) => ({ ...prev, [key]: value }));
-      void repository.save(key, value);
+      repository.save(key, value).catch((e) => {
+        captureException(e, {
+          operation: 'SettingsRepository.save',
+          key,
+          value,
+        });
+      });
     },
     [repository],
   );
 
   const resetSettings = useCallback(() => {
     setSettings(DEFAULT_SETTINGS);
-    void repository.resetAll();
+    repository.resetAll().catch((e) => {
+      captureException(e, {
+        operation: 'SettingsRepository.resetAll',
+      });
+    });
   }, [repository]);
 
   return (

--- a/src/hooks/__tests__/useRecordings.test.ts
+++ b/src/hooks/__tests__/useRecordings.test.ts
@@ -1,3 +1,9 @@
+jest.mock('../../lib/sentryHelpers', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+  addBreadcrumb: jest.fn(),
+}));
+
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { useRecordings } from '../useRecordings';
 import { StubRecordingsRepository } from '../../__tests__/stubs/stubRecordingsRepository';

--- a/src/hooks/__tests__/useVoiceMirror.test.ts
+++ b/src/hooks/__tests__/useVoiceMirror.test.ts
@@ -1,3 +1,9 @@
+jest.mock('../../lib/sentryHelpers', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+  addBreadcrumb: jest.fn(),
+}));
+
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { useVoiceMirror } from '../useVoiceMirror';
 import { StubAudioRecordingService } from '../../__tests__/stubs/stubAudioRecordingService';

--- a/src/hooks/useRecordings.ts
+++ b/src/hooks/useRecordings.ts
@@ -5,6 +5,7 @@ import { usePlaybackLevelHistory } from './usePlaybackLevelHistory';
 import type { Recording } from '../lib/recordings';
 import type { IRecordingsRepository } from '../repositories/RecordingsRepository';
 import type { IAudioDecoderService } from '../services/AudioDecoderService';
+import { captureException, addBreadcrumb } from '../lib/sentryHelpers';
 
 export type PlayState = { recordingId: string; isPlaying: boolean } | null;
 
@@ -130,6 +131,12 @@ export function useRecordings(
       audioBuffer = await decoderService.decodeAudioData(recording.filePath, audioContext.sampleRate);
     } catch (e) {
       console.error('[useRecordings] decodeAudioData failed:', e);
+      captureException(e, {
+        operation: 'AudioDecoder.decodeAudioData',
+        filePath: recording.filePath,
+        recordingId: recording.id,
+        sampleRate: audioContext.sampleRate,
+      });
       isDecodingRef.current = false;
       setPlayState(null);
       await options.onDidStop();
@@ -149,6 +156,10 @@ export function useRecordings(
       void options.onDidStop();
     };
     source.start(0);
+    addBreadcrumb('recordings', 'List playback started', {
+      recordingId: recording.id,
+      durationMs: recording.durationMs,
+    });
     startPlaybackLevels(audioBuffer, 0, setLevelHistory);
   }, [playState, audioContext, decoderService, stopCurrentPlayer, options, startPlaybackLevels, stopPlaybackLevels]);
 

--- a/src/hooks/useVoiceMirror.ts
+++ b/src/hooks/useVoiceMirror.ts
@@ -8,6 +8,7 @@ import type { IAudioRecordingService, IAudioRecorder } from '../services/AudioRe
 import type { IAudioEncoderService } from '../services/AudioEncoderService';
 import type { IRecordingsRepository } from '../repositories/RecordingsRepository';
 import type { DetectionSettings } from '../types/settings';
+import { captureException, captureMessage, addBreadcrumb } from '../lib/sentryHelpers';
 
 const BUFFER_LENGTH = 4096;
 const CHANNEL_COUNT = 1;
@@ -61,9 +62,11 @@ export function useVoiceMirror(
       const status = await recordingService.requestRecordingPermissions();
       if (status !== 'Granted') {
         setPermissionDenied(true);
+        addBreadcrumb('voicemirror', 'Microphone permission denied', undefined, 'warning');
         return;
       }
       setHasPermission(true);
+      addBreadcrumb('voicemirror', 'Microphone permission granted');
       recordingService.setAudioSessionOptions({
         iosCategory: 'playAndRecord',
         iosOptions: ['defaultToSpeaker'],
@@ -89,6 +92,11 @@ export function useVoiceMirror(
       pendingFilePathRef.current = filePath;
     } catch (e) {
       console.error('[AudioEncoder] startEncoding failed:', e);
+      captureException(e, {
+        operation: 'AudioEncoder.startEncoding',
+        filePath,
+        sampleRate: context.sampleRate,
+      });
       return;
     }
 
@@ -107,6 +115,11 @@ export function useVoiceMirror(
         encoderService.encodeChunk(slice);
       } catch (e) {
         console.error('[AudioEncoder] encodeChunk failed:', e);
+        captureException(e, {
+          operation: 'AudioEncoder.encodeChunk',
+          phase: 'catchup',
+          filePath,
+        });
         encoderFailedRef.current = true;
       }
     }
@@ -130,6 +143,9 @@ export function useVoiceMirror(
           silenceStartTimeRef.current = null;
           phaseRef.current = 'recording';
           setPhase('recording');
+          addBreadcrumb('voicemirror', 'Recording started', {
+            voiceStartFrame: voiceStartFrameRef.current,
+          });
           beginEncoding();
         }
       } else {
@@ -142,6 +158,7 @@ export function useVoiceMirror(
         silenceStartTimeRef.current = null;
         phaseRef.current = 'playing';
         setPhase('playing');
+        addBreadcrumb('voicemirror', 'Recording stopped, playing back');
         void stopAndPlay();
         return;
       }
@@ -153,6 +170,7 @@ export function useVoiceMirror(
           silenceStartTimeRef.current = null;
           phaseRef.current = 'playing';
           setPhase('playing');
+          addBreadcrumb('voicemirror', 'Recording stopped, playing back');
           void stopAndPlay();
         }
       } else if (db >= s.silenceThresholdDb) {
@@ -179,6 +197,9 @@ export function useVoiceMirror(
     await recordingService.setAudioSessionActivity(true);
     await context.resume();
     recorder.start();
+    addBreadcrumb('voicemirror', 'Monitoring started', {
+      sampleRate: context.sampleRate,
+    });
 
     recorder.onAudioReady(
       { sampleRate: context.sampleRate, bufferLength: BUFFER_LENGTH, channelCount: CHANNEL_COUNT },
@@ -203,6 +224,10 @@ export function useVoiceMirror(
             encoderService.encodeChunk(chunk);
           } catch (e) {
             console.error('[AudioEncoder] encodeChunk failed:', e);
+            captureException(e, {
+              operation: 'AudioEncoder.encodeChunk',
+              phase: 'streaming',
+            });
             encoderFailedRef.current = true;
           }
         }
@@ -244,12 +269,27 @@ export function useVoiceMirror(
         ]);
         if (durationMs === 0) {
           console.error(`[AudioEncoder] stopEncoding returned 0 for ${filePath}`);
+          captureMessage('AudioEncoder stopEncoding returned duration 0', {
+            operation: 'AudioEncoder.stopEncoding',
+            filePath,
+            sampleRate: context.sampleRate,
+          });
         }
       } catch (e) {
         console.error(`[AudioEncoder] stopEncoding threw for ${filePath}:`, e);
+        captureException(e, {
+          operation: 'AudioEncoder.stopEncoding',
+          filePath,
+          sampleRate: context.sampleRate,
+        });
       }
     } else if (filePath && encoderFailedRef.current) {
       console.error(`[AudioEncoder] skipped stopEncoding due to prior chunk error: ${filePath}`);
+      captureMessage('AudioEncoder skipped stopEncoding due to prior chunk error', {
+        operation: 'AudioEncoder.stopEncoding',
+        filePath,
+        reason: 'prior_chunk_error',
+      }, 'warning');
     }
 
     if (filePath && durationMs === 0) {
@@ -295,6 +335,7 @@ export function useVoiceMirror(
   }
 
   async function pauseMonitoring() {
+    addBreadcrumb('voicemirror', 'Monitoring paused');
     if (playerNodeRef.current) {
       playerNodeRef.current.onEnded = null;
       playerNodeRef.current.stop();
@@ -314,6 +355,11 @@ export function useVoiceMirror(
           await encoderService.stopEncoding();
         } catch (e) {
           console.error('[AudioEncoder] stopEncoding failed during pause cleanup:', e);
+          captureException(e, {
+            operation: 'AudioEncoder.stopEncoding',
+            phase: 'pause_cleanup',
+            filePath,
+          });
         }
       }
       repository.deleteFile(filePath);
@@ -328,6 +374,7 @@ export function useVoiceMirror(
   }
 
   async function resumeMonitoring() {
+    addBreadcrumb('voicemirror', 'Monitoring resumed');
     await startMonitoring();
   }
 

--- a/src/lib/__tests__/recordings.test.ts
+++ b/src/lib/__tests__/recordings.test.ts
@@ -1,3 +1,9 @@
+jest.mock('../sentryHelpers', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+  addBreadcrumb: jest.fn(),
+}));
+
 import { loadRecordings, saveRecordings, newFilePath } from '../recordings';
 
 const store: Record<string, string> = {};

--- a/src/lib/recordings.ts
+++ b/src/lib/recordings.ts
@@ -1,4 +1,5 @@
 import { Directory, File, Paths } from 'expo-file-system';
+import { captureException, captureMessage } from './sentryHelpers';
 
 export interface Recording {
   id: string;
@@ -31,6 +32,11 @@ export async function loadRecordings(): Promise<Recording[]> {
       console.warn(
         `[recordings] Removing stale entry: ${recording.filePath} (file not found on disk)`,
       );
+      captureMessage('Stale recording entry removed (file missing)', {
+        operation: 'loadRecordings',
+        filePath: recording.filePath,
+        recordingId: recording.id,
+      }, 'warning');
     }
   }
 
@@ -46,10 +52,18 @@ export async function loadRecordings(): Promise<Recording[]> {
       console.warn(
         `[recordings] Deleting orphaned file: ${entry.uri} (not in index)`,
       );
+      captureMessage('Orphaned recording file deleted', {
+        operation: 'loadRecordings',
+        fileUri: entry.uri,
+      }, 'warning');
       try {
         entry.delete();
       } catch (e) {
         console.error(`[recordings] Failed to delete orphaned file: ${entry.uri}`, e);
+        captureException(e, {
+          operation: 'deleteOrphanedFile',
+          fileUri: entry.uri,
+        });
       }
     }
   }

--- a/src/lib/sentryHelpers.ts
+++ b/src/lib/sentryHelpers.ts
@@ -1,0 +1,37 @@
+import * as Sentry from '@sentry/react-native';
+
+export function captureException(
+  error: unknown,
+  context: Record<string, unknown>,
+): void {
+  Sentry.withScope((scope) => {
+    scope.setContext('operation', context);
+    Sentry.captureException(error);
+  });
+}
+
+export function captureMessage(
+  message: string,
+  context: Record<string, unknown>,
+  level: Sentry.SeverityLevel = 'error',
+): void {
+  Sentry.withScope((scope) => {
+    scope.setContext('operation', context);
+    scope.setLevel(level);
+    Sentry.captureMessage(message);
+  });
+}
+
+export function addBreadcrumb(
+  category: string,
+  message: string,
+  data?: Record<string, unknown>,
+  level: Sentry.SeverityLevel = 'info',
+): void {
+  Sentry.addBreadcrumb({
+    category,
+    message,
+    data,
+    level,
+  });
+}

--- a/src/screens/VoiceMirrorScreen.tsx
+++ b/src/screens/VoiceMirrorScreen.tsx
@@ -1,4 +1,11 @@
-import { View, Text, StyleSheet, SafeAreaView, Pressable } from "react-native";
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  Pressable,
+  Button,
+} from "react-native";
 import { useRef, useCallback } from "react";
 import { useRouter } from "expo-router";
 import { useTranslation } from "react-i18next";
@@ -78,7 +85,14 @@ function VoiceMirrorContent() {
     settings,
   );
 
-  const { recordings, playState, levelHistory: recordingsLevelHistory, addRecording, deleteRecording, togglePlay } = useRecordings(
+  const {
+    recordings,
+    playState,
+    levelHistory: recordingsLevelHistory,
+    addRecording,
+    deleteRecording,
+    togglePlay,
+  } = useRecordings(
     { onWillPlay: stableSuspend, onDidStop: stableResume },
     audioContext,
     recordingsRepository,
@@ -91,18 +105,20 @@ function VoiceMirrorContent() {
   resumeRef.current = resumeFromListPlayback;
 
   const isListPlaying = playState?.isPlaying ?? false;
-  const activeLevelHistory = isListPlaying ? recordingsLevelHistory : levelHistory;
-  const meterPhase = isListPlaying ? 'playing' as const : phase;
+  const activeLevelHistory = isListPlaying
+    ? recordingsLevelHistory
+    : levelHistory;
+  const meterPhase = isListPlaying ? ("playing" as const) : phase;
   const isPaused = phase === "paused";
   const isRecording = phase === "recording";
 
   const stateColor = isPaused
     ? colors.paused
     : isRecording
-    ? colors.recording
-    : isListPlaying
-    ? colors.playing
-    : colors.accent;
+      ? colors.recording
+      : isListPlaying
+        ? colors.playing
+        : colors.accent;
 
   if (permissionDenied) {
     return (
@@ -112,10 +128,8 @@ function VoiceMirrorContent() {
             <View style={styles.errorIconContainer}>
               <Text style={styles.errorIcon}>!</Text>
             </View>
-            <Text style={styles.errorTitle}>{t('main.error_title')}</Text>
-            <Text style={styles.errorBody}>
-              {t('main.error_body')}
-            </Text>
+            <Text style={styles.errorTitle}>{t("main.error_title")}</Text>
+            <Text style={styles.errorBody}>{t("main.error_body")}</Text>
           </View>
         </View>
       </SafeAreaView>
@@ -128,7 +142,7 @@ function VoiceMirrorContent() {
         <View style={styles.center}>
           <View style={styles.loadingContainer}>
             <View style={styles.loadingDot} />
-            <Text style={styles.hint}>{t('main.hint_requesting')}</Text>
+            <Text style={styles.hint}>{t("main.hint_requesting")}</Text>
           </View>
         </View>
       </SafeAreaView>
@@ -151,7 +165,6 @@ function VoiceMirrorContent() {
           </View>
         </Pressable>
       </View>
-      
       <View style={[styles.monitorCard, { borderColor: stateColor }]}>
         <PhaseDisplay phase={meterPhase} />
         <View style={[styles.waveformBox, { borderColor: `${stateColor}33` }]}>
@@ -164,11 +177,13 @@ function VoiceMirrorContent() {
           />
         </View>
         <Text style={styles.hint}>
-          {isPaused ? t('main.hint_paused') : t('main.hint_listening')}
+          {isPaused ? t("main.hint_paused") : t("main.hint_listening")}
         </Text>
         {recordingError && (
           <View style={styles.errorBadge}>
-            <Text style={styles.recordingError}>{t(`main.${recordingError}`)}</Text>
+            <Text style={styles.recordingError}>
+              {t(`main.${recordingError}`)}
+            </Text>
           </View>
         )}
         <Pressable
@@ -182,14 +197,16 @@ function VoiceMirrorContent() {
           ]}
         >
           <Text style={[styles.pauseButtonLabel, { color: stateColor }]}>
-            {isPaused ? t('main.button_resume') : t('main.button_pause')}
+            {isPaused ? t("main.button_resume") : t("main.button_pause")}
           </Text>
         </Pressable>
       </View>
 
       <View style={styles.recordingsSection}>
         <View style={styles.recordingsHeader}>
-          <Text style={styles.recordingsTitle}>{t('recordings.title') || 'Recordings'}</Text>
+          <Text style={styles.recordingsTitle}>
+            {t("recordings.title") || "Recordings"}
+          </Text>
           <View style={styles.recordingsCountBadge}>
             <Text style={styles.recordingsCount}>{recordings.length}</Text>
           </View>


### PR DESCRIPTION
## Summary

- Add `src/lib/sentryHelpers.ts` with centralized `captureException`, `captureMessage`, and `addBreadcrumb` wrappers that attach structured operation context
- Add explicit Sentry captures at every existing `catch` block and `console.error` site across 5 files (`useVoiceMirror.ts`, `useRecordings.ts`, `recordings.ts`, `SettingsProvider.tsx`, `AudioContextProvider.tsx`)
- Add breadcrumbs at key state transitions (permission granted/denied, monitoring start/pause/resume, recording start, playback start) for Sentry event timeline context

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new warnings)
- [x] `pnpm test:ci` — all 113 tests pass with `jest.mock` for sentryHelpers added to affected test files
- [ ] Manual test: trigger an encoding error and verify the event appears in Sentry dashboard with structured context
- [ ] Manual test: verify breadcrumbs appear in Sentry event timeline during normal voice mirror usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)