### PR TITLE
Add Prettier auto-formatting with CI check and Claude Code hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,5 +27,18 @@
       "Bash(./gradlew *)",
       "Bash(python3 -m json.tool)"
     ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | xargs pnpm prettier --write"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,8 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Format check
+        run: pnpm format:check
+
       - name: Unit tests
         run: pnpm test:ci

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": false
+}

--- a/app.json
+++ b/app.json
@@ -46,18 +46,13 @@
         "react-native-audio-api",
         {
           "iosMicrophonePermission": "VoiceMirror records your voice so you can immediately hear yourself back.",
-          "androidPermissions": [
-            "android.permission.RECORD_AUDIO"
-          ]
+          "androidPermissions": ["android.permission.RECORD_AUDIO"]
         }
       ],
       [
         "expo-localization",
         {
-          "supportedLocales": [
-            "en",
-            "ja"
-          ]
+          "supportedLocales": ["en", "ja"]
         }
       ],
       [

--- a/e2e/helpers/E2EAudioBridge.ts
+++ b/e2e/helpers/E2EAudioBridge.ts
@@ -2,7 +2,10 @@ import { WebSocketServer, WebSocket } from "ws";
 import { createServer } from "http";
 import { DEFAULT_SETTINGS } from "../../src/types/settings";
 
-const { voiceThresholdDb: VOICE_THRESHOLD_DB, silenceThresholdDb: SILENCE_THRESHOLD_DB } = DEFAULT_SETTINGS;
+const {
+  voiceThresholdDb: VOICE_THRESHOLD_DB,
+  silenceThresholdDb: SILENCE_THRESHOLD_DB,
+} = DEFAULT_SETTINGS;
 
 const CHUNK_FRAMES = 4096;
 const E2E_SAMPLE_RATE = 48000;

--- a/e2e/specs/voiceMirror.spec.ts
+++ b/e2e/specs/voiceMirror.spec.ts
@@ -1,7 +1,11 @@
 import { E2EAudioBridge } from "../helpers/E2EAudioBridge";
 import { DEFAULT_SETTINGS } from "../../src/types/settings";
 
-const { voiceOnsetMs: VOICE_ONSET_MS, minRecordingMs: MIN_RECORDING_MS, silenceDurationMs: SILENCE_DURATION_MS } = DEFAULT_SETTINGS;
+const {
+  voiceOnsetMs: VOICE_ONSET_MS,
+  minRecordingMs: MIN_RECORDING_MS,
+  silenceDurationMs: SILENCE_DURATION_MS,
+} = DEFAULT_SETTINGS;
 
 // Appium/UiAutomator2 on Android emulators can be extremely slow (10-20s per command).
 // These timeouts account for that latency.
@@ -172,7 +176,10 @@ describeSwipe("VoiceMirror — swipe to delete", () => {
         const count = await $$(sel).length;
         return count === 0;
       },
-      { timeout: WAIT_SHORT, timeoutMsg: "Recording was not deleted by full swipe" },
+      {
+        timeout: WAIT_SHORT,
+        timeoutMsg: "Recording was not deleted by full swipe",
+      },
     );
   });
 });

--- a/e2e/wdio.ios.conf.ts
+++ b/e2e/wdio.ios.conf.ts
@@ -1,43 +1,44 @@
-import path from 'path';
-import type { Options, Capabilities } from '@wdio/types';
-import { config as dotenvConfig } from 'dotenv';
+import path from "path";
+import type { Options, Capabilities } from "@wdio/types";
+import { config as dotenvConfig } from "dotenv";
 
 dotenvConfig();
 
-type WdioConfig = Options.Testrunner & Capabilities.WithRequestedTestrunnerCapabilities;
+type WdioConfig = Options.Testrunner &
+  Capabilities.WithRequestedTestrunnerCapabilities;
 
 export const config: WdioConfig = {
-  runner: 'local',
+  runner: "local",
 
-  specs: ['./specs/**/*.spec.ts'],
+  specs: ["./specs/**/*.spec.ts"],
   exclude: [],
   maxInstances: 1,
 
   capabilities: [
     {
-      platformName: 'iOS',
-      'appium:deviceName': process.env.E2E_IOS_DEVICE_NAME ?? 'iPhone 17 Pro',
-      'appium:platformVersion': process.env.E2E_IOS_PLATFORM_VERSION ?? '26.3',
-      'appium:automationName': 'XCUITest',
-      'appium:app': path.resolve(__dirname, '../artifacts/VoiceMirror.app'),
-      'appium:noReset': false,
+      platformName: "iOS",
+      "appium:deviceName": process.env.E2E_IOS_DEVICE_NAME ?? "iPhone 17 Pro",
+      "appium:platformVersion": process.env.E2E_IOS_PLATFORM_VERSION ?? "26.3",
+      "appium:automationName": "XCUITest",
+      "appium:app": path.resolve(__dirname, "../artifacts/VoiceMirror.app"),
+      "appium:noReset": false,
     },
   ],
 
-  logLevel: 'info',
+  logLevel: "info",
   bail: 0,
-  baseUrl: 'http://localhost',
+  baseUrl: "http://localhost",
   waitforTimeout: 30_000,
   connectionRetryTimeout: 120_000,
   connectionRetryCount: 3,
 
-  services: [['appium', { args: { logLevel: 'warn' } }]],
-  framework: 'mocha',
+  services: [["appium", { args: { logLevel: "warn" } }]],
+  framework: "mocha",
 
   mochaOpts: {
-    ui: 'bdd',
+    ui: "bdd",
     timeout: 120_000,
   },
 
-  reporters: ['spec'],
+  reporters: ["spec"],
 };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,10 +1,12 @@
 // https://docs.expo.dev/guides/using-eslint/
-const { defineConfig } = require('eslint/config');
+const { defineConfig } = require("eslint/config");
 const expoConfig = require("eslint-config-expo/flat");
+const eslintPluginPrettierRecommended = require("eslint-plugin-prettier/recommended");
 
 module.exports = defineConfig([
   expoConfig,
+  eslintPluginPrettierRecommended,
   {
     ignores: ["dist/*"],
-  }
+  },
 ]);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "e2e:ios": "wdio run e2e/wdio.ios.conf.ts",
     "e2e:android": "wdio run e2e/wdio.android.conf.ts",
     "test": "jest --watchAll",
-    "test:ci": "jest --passWithNoTests"
+    "test:ci": "jest --passWithNoTests",
+    "format": "prettier --write 'src/**/*.{ts,tsx}' 'app/**/*.{ts,tsx}' 'e2e/**/*.ts' '*.{js,ts,json}'",
+    "format:check": "prettier --check 'src/**/*.{ts,tsx}' 'app/**/*.{ts,tsx}' 'e2e/**/*.ts' '*.{js,ts,json}'"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.1.1",
@@ -66,8 +68,11 @@
     "dotenv": "^17.3.1",
     "eslint": "^9.39.4",
     "eslint-config-expo": "~55.0.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-prettier": "^5.5.5",
     "jest": "~29.7.0",
     "jest-expo": "~55.0.11",
+    "prettier": "^3.8.2",
     "typescript": "~5.9.2",
     "ws": "^8.20.0"
   },

--- a/plans/20260414-auto-prettify.md
+++ b/plans/20260414-auto-prettify.md
@@ -1,0 +1,295 @@
+# Auto-Prettify -- Implementation Plan
+
+## Goal
+
+Eliminate unrelated formatting changes from diffs by ensuring all code is consistently formatted. The approach has three parts:
+
+1. **Add a `format` npm script** that runs Prettier on all source files, so formatting can be applied in one command.
+2. **Run `format` as a Claude Code hook** after every file edit/write, so that any code Claude produces is immediately formatted before being committed.
+3. **Add a CI check** that fails the build if any files are not properly formatted, catching unformatted code from any source (manual edits, other tools, etc.).
+
+This builds on the prior research in `research.md`, which identified the three packages needed (`prettier`, `eslint-config-prettier`, `eslint-plugin-prettier`) and the recommended ESLint integration pattern from the Expo docs.
+
+## Architecture / Approach
+
+### Part 1: Prettier setup and the `format` script
+
+The research document already details the recommended Expo approach: integrate Prettier into ESLint via `eslint-plugin-prettier/recommended`. However, for the hook use case we need a **standalone Prettier CLI command** that can quickly format files without running the full ESLint pipeline. The `format` script will use the Prettier CLI directly.
+
+The ESLint integration (via `eslint-plugin-prettier/recommended`) will also be added so that `pnpm lint` catches formatting violations alongside linting errors. This gives us two complementary tools:
+
+- `pnpm format` -- fast, write-mode formatting (for hooks and manual use)
+- `pnpm lint` -- full linting including formatting checks (for CI and editor integration)
+
+#### Packages to install
+
+```
+npx expo install prettier eslint-config-prettier eslint-plugin-prettier --dev
+```
+
+These three packages are the standard set recommended by the Expo docs (see `research.md` for version details).
+
+#### `.prettierrc` configuration
+
+Since the project currently uses double quotes throughout, Prettier's defaults (which also use double quotes) will minimize churn on the initial formatting commit. A minimal `.prettierrc` is still recommended to make the configuration explicit and prevent parent-directory configs from affecting the project.
+
+**New file: `.prettierrc`**
+
+```json
+{
+  "singleQuote": false
+}
+```
+
+This explicitly documents the choice of double quotes. All other options (2-space indent, semicolons, trailing commas, etc.) use Prettier defaults, which already match the project's current style.
+
+#### `format` npm script
+
+**File: `package.json`** -- add to `"scripts"`:
+
+```json
+"format": "prettier --write 'src/**/*.{ts,tsx}' 'app/**/*.{ts,tsx}' 'e2e/**/*.ts' '*.{js,ts,json}'"
+```
+
+This targets:
+
+- `src/**/*.{ts,tsx}` -- all application source files
+- `app/**/*.{ts,tsx}` -- Expo Router page files
+- `e2e/**/*.ts` -- E2E test files
+- `*.{js,ts,json}` -- root config files (`eslint.config.js`, `tsconfig.json`, `package.json`, etc.)
+
+It deliberately excludes `node_modules`, `dist`, `ios`, `android`, and `artifacts` (all of which are either generated or gitignored).
+
+A corresponding `format:check` script is needed for CI:
+
+```json
+"format:check": "prettier --check 'src/**/*.{ts,tsx}' 'app/**/*.{ts,tsx}' 'e2e/**/*.ts' '*.{js,ts,json}'"
+```
+
+`--check` mode exits with a non-zero code if any file would be changed, without actually modifying anything.
+
+#### ESLint integration
+
+**File: `eslint.config.js`** -- updated to include the Prettier plugin:
+
+```js
+// https://docs.expo.dev/guides/using-eslint/
+const { defineConfig } = require("eslint/config");
+const expoConfig = require("eslint-config-expo/flat");
+const eslintPluginPrettierRecommended = require("eslint-plugin-prettier/recommended");
+
+module.exports = defineConfig([
+  expoConfig,
+  eslintPluginPrettierRecommended,
+  {
+    ignores: ["dist/*"],
+  },
+]);
+```
+
+Order matters: `eslintPluginPrettierRecommended` must come after `expoConfig` so it can disable conflicting formatting rules from `eslint-config-expo`.
+
+### Part 2: Claude Code hook
+
+Claude Code hooks allow running commands automatically at specific lifecycle events. The relevant event for auto-formatting is **`PostToolUse`** on the `Edit` and `Write` tools -- i.e., after Claude writes or edits a file, the hook formats it immediately.
+
+The hook is configured in the **project-level** `.claude/settings.json` so it applies to all developers working on the project with Claude Code.
+
+**File: `.claude/settings.json`** -- add `hooks` key:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(cat:*)",
+      "Bash(ls:*)",
+      "Bash(grep *)",
+      "Bash(find *)",
+      "Bash(pnpm *)",
+      "Bash(git *)",
+      "Bash(aapt dump:*)",
+      "Bash(adb logcat:*)",
+      "Bash(pod install:*)",
+      "Bash(npx expo:*)",
+      "Bash(npx eas-cli@latest update *)",
+      "Bash(npx eas-cli@latest build:list*)",
+      "Bash(npx eas-cli@latest build:cancel*)",
+      "Bash(mkdir -p src/*)",
+      "Edit(research.md)",
+      "Edit(plans/*.md)",
+      "WebFetch(domain:docs.expo.dev)",
+      "WebFetch(domain:docs.swmansion.com)",
+      "WebSearch",
+      "Bash(pod install:*)",
+      "Bash(npx expo-modules-autolinking:*)",
+      "WebFetch(domain:react.i18next.com)",
+      "WebFetch(domain:www.i18next.com)",
+      "Bash(./gradlew *)",
+      "Bash(python3 -m json.tool)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | xargs pnpm prettier --write"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### How the hook works
+
+- **Event**: `PostToolUse` fires after Claude successfully uses a tool.
+- **Matcher**: `"Edit|Write"` restricts the hook to fire only after `Edit` or `Write` tool calls (not after `Bash`, `Read`, etc.).
+- **Stdin JSON**: Claude Code passes event data as JSON to stdin, containing `tool_input.file_path` with the absolute path of the file that was just edited or written.
+- **Command**: `jq -r '.tool_input.file_path' | xargs pnpm prettier --write` extracts the file path from stdin and formats just that single file, keeping the hook fast (sub-second for a single file).
+
+This means every file Claude touches is automatically formatted before the user sees it or it gets committed, preventing formatting-only diffs from leaking into PRs.
+
+### Part 3: CI format check
+
+The existing CI workflow at `.github/workflows/ci.yml` needs a new step that runs `pnpm format:check` to reject PRs containing unformatted code.
+
+**File: `.github/workflows/ci.yml`** -- add a step after "Lint":
+
+```yaml
+- name: Lint
+  run: pnpm lint
+
+- name: Format check
+  run: pnpm format:check
+
+- name: Unit tests
+  run: pnpm test:ci
+```
+
+The `format:check` step runs `prettier --check`, which:
+
+- Exits 0 if all files are already formatted
+- Exits 1 and prints the list of unformatted files if any file would be changed
+
+This is placed after "Lint" because linting is conceptually related (both are style checks), and before "Unit tests" because tests are the most expensive step.
+
+### Initial formatting commit
+
+After setting everything up, the entire codebase must be formatted once via `pnpm format`. This will produce a single commit that touches many files. To preserve `git blame` history:
+
+1. Run `pnpm format` and commit all changes
+2. Create a `.git-blame-ignore-revs` file at the project root containing the formatting commit hash
+3. GitHub automatically reads this file and hides the commit from blame views
+
+**New file: `.git-blame-ignore-revs`**
+
+```
+# Prettier formatting pass
+<commit-hash-to-be-filled-after-commit>
+```
+
+## File Paths That Need Modification
+
+| File                       | Change                                                                          |
+| -------------------------- | ------------------------------------------------------------------------------- |
+| `package.json`             | Add `"format"` and `"format:check"` scripts; add three Prettier devDependencies |
+| `.prettierrc`              | New file -- Prettier configuration                                              |
+| `eslint.config.js`         | Add `eslint-plugin-prettier/recommended` to the config array                    |
+| `.claude/settings.json`    | Add `hooks.PostToolUse` for auto-formatting                                     |
+| `.github/workflows/ci.yml` | Add "Format check" step                                                         |
+| `.git-blame-ignore-revs`   | New file -- list the formatting commit for blame exclusion                      |
+
+## Considerations and Trade-offs
+
+### Standalone Prettier CLI vs. ESLint-only formatting
+
+**Chosen**: Both. `pnpm format` uses the Prettier CLI directly; `pnpm lint` includes Prettier via ESLint plugin.
+
+**Why both**: The Claude Code hook needs a fast single-file formatting command. Running `eslint --fix` on a single file is slower because it loads the full ESLint rule set. The Prettier CLI formats a single file in ~50ms. Meanwhile, having Prettier in ESLint ensures `pnpm lint` catches formatting issues alongside other lint violations, which is the standard Expo-recommended approach.
+
+**Trade-off**: Two code paths for formatting means they must share the same config. Both read from `.prettierrc`, so they are guaranteed to agree. The ESLint plugin passes `usePrettierrc: true` by default, so it uses the same `.prettierrc` as the CLI.
+
+### Hook placement: project vs. user settings
+
+**Chosen**: Project-level `.claude/settings.json`.
+
+The hook is a project concern (ensuring consistent formatting), not a user preference. Placing it in the project settings means every developer using Claude Code on this project gets auto-formatting without additional setup. The user-level settings at `~/.claude/settings.json` already has user-specific hooks (`Stop` and `Notification`), which are appropriately personal.
+
+### `PostToolUse` on Edit|Write vs. a pre-commit hook
+
+**Chosen**: Claude Code hook (`PostToolUse`).
+
+**Alternative**: A Git pre-commit hook (e.g., via `lint-staged` + `husky`) that formats staged files before every commit. This is a more traditional approach and catches all contributors, not just Claude Code.
+
+**Why PostToolUse**: The stated goal is specifically to prevent Claude Code from producing unrelated formatting changes. A `PostToolUse` hook formats immediately after each edit, so the user sees clean diffs in real-time. The CI `format:check` step serves as the universal safety net that catches unformatted code from any source.
+
+A pre-commit hook with `lint-staged` could be added later as a complementary measure for human developers, but it is not part of this plan since the immediate problem is Claude Code-generated diffs.
+
+### `format:check` vs. relying on `pnpm lint`
+
+**Chosen**: A separate `format:check` step using the Prettier CLI.
+
+Since `eslint-plugin-prettier` is added to the ESLint config, `pnpm lint` will also catch formatting issues. However, having a dedicated `pnpm format:check` step in CI provides:
+
+- A clearer failure message (Prettier's output lists exactly which files need formatting)
+- Faster feedback (Prettier check is faster than full ESLint with Prettier plugin)
+- Independence from ESLint config changes (if someone accidentally removes the Prettier plugin from ESLint, the CI still catches formatting issues)
+
+The redundancy is intentional and low-cost.
+
+### Double quotes vs. single quotes
+
+**Chosen**: Double quotes (Prettier default, matching current codebase).
+
+The research document notes that Expo and React Native community conventions prefer single quotes. However, switching to single quotes would reformat every string in every file, creating a massive diff with no functional benefit. Keeping double quotes minimizes churn in the initial formatting commit. If the team wants to switch to single quotes later, it is a one-line change in `.prettierrc` followed by `pnpm format`.
+
+### Files targeted by `format` script
+
+**Chosen**: Explicit glob patterns targeting `src/`, `app/`, `e2e/`, and root config files.
+
+**Alternative**: `prettier --write .` with a `.prettierignore` file to exclude unwanted directories.
+
+**Why explicit globs**: The project has several directories that should never be formatted (`node_modules`, `ios`, `android`, `dist`, `artifacts`, `.expo`). Using explicit include patterns is safer than trying to exclude everything. It also makes the scope of formatting immediately visible in the script definition. A `.prettierignore` file would be needed alongside `prettier --write .` to avoid formatting these directories, and forgetting an entry would cause unexpected changes.
+
+### `.git-blame-ignore-revs` for the initial formatting commit
+
+The initial `pnpm format` run will change most source files. Without `.git-blame-ignore-revs`, `git blame` would attribute many lines to the formatting commit rather than their original authors. GitHub reads this file automatically. For local use, developers can run `git config blame.ignoreRevsFile .git-blame-ignore-revs` once per clone.
+
+This is a best practice when introducing a formatter to an existing codebase and has no downsides.
+
+## Todo
+
+### Part 1: Prettier setup and the `format` script
+
+- [x] Install dev dependencies: `npx expo install prettier eslint-config-prettier eslint-plugin-prettier --dev`
+- [x] Create `.prettierrc` with `{ "singleQuote": false }`
+- [x] Add `"format"` script to `package.json`: `prettier --write 'src/**/*.{ts,tsx}' 'app/**/*.{ts,tsx}' 'e2e/**/*.ts' '*.{js,ts,json}'`
+- [x] Add `"format:check"` script to `package.json`: `prettier --check 'src/**/*.{ts,tsx}' 'app/**/*.{ts,tsx}' 'e2e/**/*.ts' '*.{js,ts,json}'`
+- [x] Update `eslint.config.js`: import `eslint-plugin-prettier/recommended` and add it to the config array after `expoConfig`
+- [x] Verify `pnpm lint` runs successfully with the new Prettier ESLint integration
+
+### Part 2: Claude Code hook
+
+- [x] Add `hooks.PostToolUse` entry to `.claude/settings.json` with matcher `"Edit|Write"` and command `pnpm prettier --write $CLAUDE_FILE_PATH`
+
+### Part 3: CI format check
+
+- [x] Add "Format check" step (`pnpm format:check`) to `.github/workflows/ci.yml` after the "Lint" step and before the "Unit tests" step
+
+### Part 4: Initial formatting commit
+
+- [x] Run `pnpm format` to format the entire codebase
+- [ ] Commit all formatting changes as a single commit
+- [ ] Create `.git-blame-ignore-revs` file at project root containing the formatting commit hash
+- [ ] Commit `.git-blame-ignore-revs`
+
+### Verification
+
+- [x] Run `pnpm typecheck` to confirm no type errors
+- [x] Run `pnpm lint` to confirm no lint/formatting errors
+- [x] Run `pnpm test:ci` to confirm unit tests pass
+- [x] Run `pnpm format:check` to confirm all files are formatted

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,12 +123,21 @@ importers:
       eslint-config-expo:
         specifier: ~55.0.0
         version: 55.0.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-prettier:
+        specifier: ^5.5.5
+        version: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.2)
       jest:
         specifier: ~29.7.0
         version: 29.7.0(@types/node@25.5.0)
       jest-expo:
         specifier: ~55.0.11
         version: 55.0.11(@babel/core@7.29.0)(expo@55.0.5)(jest@29.7.0(@types/node@25.5.0))(react-native@0.83.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      prettier:
+        specifier: ^3.8.2
+        version: 3.8.2
       typescript:
         specifier: ~5.9.2
         version: 5.9.3
@@ -1507,6 +1516,10 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@pkgr/core@0.2.9':
+    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@promptbook/utils@0.69.5':
     resolution: {integrity: sha512-xm5Ti/Hp3o4xHrsK9Yy3MS6KbDxYbq485hDsFvxqaNA7equHLPdo8H8faTitTeb14QCDfLW4iwCxdVYu5sn6YQ==}
@@ -3504,6 +3517,12 @@ packages:
     peerDependencies:
       eslint: '>=8.10'
 
+  eslint-config-prettier@10.1.8:
+    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
   eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
 
@@ -3555,6 +3574,20 @@ packages:
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
     peerDependenciesMeta:
       '@typescript-eslint/parser':
+        optional: true
+
+  eslint-plugin-prettier@5.5.5:
+    resolution: {integrity: sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      '@types/eslint': '>=8.0.0'
+      eslint: '>=8.0.0'
+      eslint-config-prettier: '>= 7.0.0 <10.0.0 || >=10.1.0'
+      prettier: '>=3.0.0'
+    peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
+      eslint-config-prettier:
         optional: true
 
   eslint-plugin-react-hooks@5.2.0:
@@ -3865,6 +3898,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
@@ -5740,6 +5776,15 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier-linter-helpers@1.0.1:
+    resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
+    engines: {node: '>=6.0.0'}
+
+  prettier@3.8.2:
+    resolution: {integrity: sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -6550,6 +6595,10 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  synckit@0.11.12:
+    resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -8874,6 +8923,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@pkgr/core@0.2.9': {}
 
   '@promptbook/utils@0.69.5':
     dependencies:
@@ -11457,6 +11508,10 @@ snapshots:
       - supports-color
       - typescript
 
+  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+
   eslint-import-resolver-node@0.3.9:
     dependencies:
       debug: 3.2.7(supports-color@10.2.2)
@@ -11528,6 +11583,15 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+
+  eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.2):
+    dependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+      prettier: 3.8.2
+      prettier-linter-helpers: 1.0.1
+      synckit: 0.11.12
+    optionalDependencies:
+      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.6.1))
 
   eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
@@ -11990,6 +12054,8 @@ snapshots:
   fast-deep-equal@2.0.1: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-diff@1.3.0: {}
 
   fast-fifo@1.3.2: {}
 
@@ -14327,6 +14393,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  prettier-linter-helpers@1.0.1:
+    dependencies:
+      fast-diff: 1.3.0
+
+  prettier@3.8.2: {}
+
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
@@ -15310,6 +15382,10 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  synckit@0.11.12:
+    dependencies:
+      '@pkgr/core': 0.2.9
 
   tagged-tag@1.0.0: {}
 

--- a/src/__tests__/stubs/stubAudioContext.ts
+++ b/src/__tests__/stubs/stubAudioContext.ts
@@ -1,5 +1,5 @@
-import type { AudioContext, AudioBuffer } from 'react-native-audio-api';
-import { makeStubAudioBuffer } from './stubAudioDecoderService';
+import type { AudioContext, AudioBuffer } from "react-native-audio-api";
+import { makeStubAudioBuffer } from "./stubAudioDecoderService";
 
 export type StubAudioBufferSourceNode = {
   buffer: AudioBuffer | null;
@@ -22,7 +22,7 @@ export function makeStubBufferSourceNode(): StubAudioBufferSourceNode {
 export function makeStubAudioContext(sampleRate = 44100): AudioContext {
   return {
     sampleRate,
-    destination: {} as AudioContext['destination'],
+    destination: {} as AudioContext["destination"],
     createBuffer: jest.fn(() => makeStubAudioBuffer(sampleRate, sampleRate)),
     createBufferSource: jest.fn(() => makeStubBufferSourceNode()),
     resume: jest.fn().mockResolvedValue(undefined),

--- a/src/__tests__/stubs/stubAudioDecoderService.ts
+++ b/src/__tests__/stubs/stubAudioDecoderService.ts
@@ -1,7 +1,11 @@
-import type { IAudioDecoderService } from '../../services/AudioDecoderService';
-import type { AudioBuffer } from 'react-native-audio-api';
+import type { IAudioDecoderService } from "../../services/AudioDecoderService";
+import type { AudioBuffer } from "react-native-audio-api";
 
-export function makeStubAudioBuffer(length = 44100, sampleRate = 44100, amplitude = 0): AudioBuffer {
+export function makeStubAudioBuffer(
+  length = 44100,
+  sampleRate = 44100,
+  amplitude = 0,
+): AudioBuffer {
   const data = new Float32Array(length).fill(amplitude);
   return {
     length,
@@ -15,5 +19,7 @@ export function makeStubAudioBuffer(length = 44100, sampleRate = 44100, amplitud
 }
 
 export class StubAudioDecoderService implements IAudioDecoderService {
-  decodeAudioData: jest.Mock<Promise<AudioBuffer>, [string, number]> = jest.fn().mockResolvedValue(makeStubAudioBuffer());
+  decodeAudioData: jest.Mock<Promise<AudioBuffer>, [string, number]> = jest
+    .fn()
+    .mockResolvedValue(makeStubAudioBuffer());
 }

--- a/src/__tests__/stubs/stubAudioEncoderService.ts
+++ b/src/__tests__/stubs/stubAudioEncoderService.ts
@@ -1,4 +1,4 @@
-import type { IAudioEncoderService } from '../../services/AudioEncoderService';
+import type { IAudioEncoderService } from "../../services/AudioEncoderService";
 
 export class StubAudioEncoderService implements IAudioEncoderService {
   startEncoding: jest.Mock<void, [string, number]> = jest.fn();

--- a/src/__tests__/stubs/stubAudioRecordingService.ts
+++ b/src/__tests__/stubs/stubAudioRecordingService.ts
@@ -1,12 +1,22 @@
-import type { IAudioRecordingService, IAudioRecorder, AudioChunkEvent } from '../../services/AudioRecordingService';
-import type { AudioRecorderCallbackOptions, PermissionStatus, SessionOptions } from 'react-native-audio-api';
+import type {
+  IAudioRecordingService,
+  IAudioRecorder,
+  AudioChunkEvent,
+} from "../../services/AudioRecordingService";
+import type {
+  AudioRecorderCallbackOptions,
+  PermissionStatus,
+  SessionOptions,
+} from "react-native-audio-api";
 
 export class StubAudioRecorder implements IAudioRecorder {
   private callback: ((event: AudioChunkEvent) => void) | null = null;
 
   start = jest.fn();
   stop = jest.fn();
-  clearOnAudioReady = jest.fn(() => { this.callback = null; });
+  clearOnAudioReady = jest.fn(() => {
+    this.callback = null;
+  });
 
   onAudioReady(
     _config: AudioRecorderCallbackOptions,
@@ -23,8 +33,12 @@ export class StubAudioRecorder implements IAudioRecorder {
 export class StubAudioRecordingService implements IAudioRecordingService {
   readonly recorder = new StubAudioRecorder();
 
-  requestRecordingPermissions: jest.Mock<Promise<PermissionStatus>> = jest.fn().mockResolvedValue('Granted' as PermissionStatus);
+  requestRecordingPermissions: jest.Mock<Promise<PermissionStatus>> = jest
+    .fn()
+    .mockResolvedValue("Granted" as PermissionStatus);
   setAudioSessionOptions: jest.Mock<void, [SessionOptions]> = jest.fn();
-  setAudioSessionActivity: jest.Mock<Promise<void>, [boolean]> = jest.fn().mockResolvedValue(undefined);
+  setAudioSessionActivity: jest.Mock<Promise<void>, [boolean]> = jest
+    .fn()
+    .mockResolvedValue(undefined);
   createRecorder: jest.Mock<IAudioRecorder> = jest.fn(() => this.recorder);
 }

--- a/src/__tests__/stubs/stubRecordingsRepository.ts
+++ b/src/__tests__/stubs/stubRecordingsRepository.ts
@@ -1,13 +1,17 @@
-import type { IRecordingsRepository } from '../../repositories/RecordingsRepository';
-import type { Recording } from '../../lib/recordings';
+import type { IRecordingsRepository } from "../../repositories/RecordingsRepository";
+import type { Recording } from "../../lib/recordings";
 
 export class StubRecordingsRepository implements IRecordingsRepository {
   private data: Recording[] = [];
   private counter = 0;
 
   load: jest.Mock<Promise<Recording[]>> = jest.fn(async () => [...this.data]);
-  save: jest.Mock<void, [Recording[]]> = jest.fn((recordings: Recording[]) => { this.data = recordings; });
-  newFilePath: jest.Mock<string> = jest.fn(() => `/tmp/recording_${++this.counter}.m4a`);
+  save: jest.Mock<void, [Recording[]]> = jest.fn((recordings: Recording[]) => {
+    this.data = recordings;
+  });
+  newFilePath: jest.Mock<string> = jest.fn(
+    () => `/tmp/recording_${++this.counter}.m4a`,
+  );
   deleteFile: jest.Mock<void, [string]> = jest.fn();
 
   seed(recordings: Recording[]): void {

--- a/src/components/PhaseDisplay.tsx
+++ b/src/components/PhaseDisplay.tsx
@@ -1,27 +1,27 @@
-import { useEffect, useRef } from 'react';
-import { View, Text, Animated, StyleSheet } from 'react-native';
-import { useTranslation } from 'react-i18next';
-import type { Phase } from '../hooks/types';
+import { useEffect, useRef } from "react";
+import { View, Text, Animated, StyleSheet } from "react-native";
+import { useTranslation } from "react-i18next";
+import type { Phase } from "../hooks/types";
 
 const PHASE_I18N_KEY: Record<Phase, string> = {
-  idle: 'phase.idle',
-  recording: 'phase.recording',
-  playing: 'phase.playing',
-  paused: 'phase.paused',
+  idle: "phase.idle",
+  recording: "phase.recording",
+  playing: "phase.playing",
+  paused: "phase.paused",
 };
 
 const PHASE_COLOR: Record<Phase, string> = {
-  idle: '#2DD4BF',
-  recording: '#F87171',
-  playing: '#5EEAD4',
-  paused: '#71717A',
+  idle: "#2DD4BF",
+  recording: "#F87171",
+  playing: "#5EEAD4",
+  paused: "#71717A",
 };
 
 const PHASE_BG: Record<Phase, string> = {
-  idle: 'rgba(45, 212, 191, 0.15)',
-  recording: 'rgba(248, 113, 113, 0.15)',
-  playing: 'rgba(94, 234, 212, 0.15)',
-  paused: 'rgba(113, 113, 122, 0.15)',
+  idle: "rgba(45, 212, 191, 0.15)",
+  recording: "rgba(248, 113, 113, 0.15)",
+  playing: "rgba(94, 234, 212, 0.15)",
+  paused: "rgba(113, 113, 122, 0.15)",
 };
 
 type Props = { phase: Phase };
@@ -34,29 +34,53 @@ export function PhaseDisplay({ phase }: Props) {
   useEffect(() => {
     const pulseAnimation = Animated.loop(
       Animated.sequence([
-        Animated.timing(pulse, { toValue: 0.4, duration: 800, useNativeDriver: true }),
-        Animated.timing(pulse, { toValue: 1.0, duration: 800, useNativeDriver: true }),
+        Animated.timing(pulse, {
+          toValue: 0.4,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+        Animated.timing(pulse, {
+          toValue: 1.0,
+          duration: 800,
+          useNativeDriver: true,
+        }),
       ]),
     );
-    
+
     const scaleAnimation = Animated.loop(
       Animated.sequence([
-        Animated.timing(scale, { toValue: 1.15, duration: 800, useNativeDriver: true }),
-        Animated.timing(scale, { toValue: 1.0, duration: 800, useNativeDriver: true }),
+        Animated.timing(scale, {
+          toValue: 1.15,
+          duration: 800,
+          useNativeDriver: true,
+        }),
+        Animated.timing(scale, {
+          toValue: 1.0,
+          duration: 800,
+          useNativeDriver: true,
+        }),
       ]),
     );
 
     const recordingScaleAnimation = Animated.loop(
       Animated.sequence([
-        Animated.timing(scale, { toValue: 1.2, duration: 500, useNativeDriver: true }),
-        Animated.timing(scale, { toValue: 1.0, duration: 500, useNativeDriver: true }),
+        Animated.timing(scale, {
+          toValue: 1.2,
+          duration: 500,
+          useNativeDriver: true,
+        }),
+        Animated.timing(scale, {
+          toValue: 1.0,
+          duration: 500,
+          useNativeDriver: true,
+        }),
       ]),
     );
 
-    if (phase === 'idle') {
+    if (phase === "idle") {
       pulseAnimation.start();
       scaleAnimation.start();
-    } else if (phase === 'recording') {
+    } else if (phase === "recording") {
       pulse.setValue(1);
       recordingScaleAnimation.start();
     } else {
@@ -79,32 +103,36 @@ export function PhaseDisplay({ phase }: Props) {
   return (
     <View style={[styles.container, { backgroundColor: bgColor }]}>
       <View style={styles.dotContainer}>
-        <Animated.View 
+        <Animated.View
           style={[
-            styles.dotGlow, 
-            { 
-              backgroundColor: color, 
+            styles.dotGlow,
+            {
+              backgroundColor: color,
               opacity: pulse,
               transform: [{ scale }],
-            }
-          ]} 
+            },
+          ]}
         />
-        <Animated.View 
+        <Animated.View
           style={[
-            styles.dot, 
-            { 
+            styles.dot,
+            {
               backgroundColor: color,
-              transform: [{ scale: Animated.multiply(scale, 0.7).interpolate({
-                inputRange: [0.7, 0.84],
-                outputRange: [1, 1.2],
-              }) }],
-            }
-          ]} 
+              transform: [
+                {
+                  scale: Animated.multiply(scale, 0.7).interpolate({
+                    inputRange: [0.7, 0.84],
+                    outputRange: [1, 1.2],
+                  }),
+                },
+              ],
+            },
+          ]}
         />
       </View>
-      <Text 
-        testID={`phase-${phase}`} 
-        accessibilityLabel={`phase-${phase}`} 
+      <Text
+        testID={`phase-${phase}`}
+        accessibilityLabel={`phase-${phase}`}
         style={[styles.label, { color }]}
       >
         {t(PHASE_I18N_KEY[phase])}
@@ -115,8 +143,8 @@ export function PhaseDisplay({ phase }: Props) {
 
 const styles = StyleSheet.create({
   container: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     gap: 12,
     paddingHorizontal: 20,
     paddingVertical: 12,
@@ -125,11 +153,11 @@ const styles = StyleSheet.create({
   dotContainer: {
     width: 16,
     height: 16,
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: "center",
+    justifyContent: "center",
   },
   dotGlow: {
-    position: 'absolute',
+    position: "absolute",
     width: 16,
     height: 16,
     borderRadius: 8,
@@ -141,8 +169,8 @@ const styles = StyleSheet.create({
   },
   label: {
     fontSize: 15,
-    fontWeight: '600',
+    fontWeight: "600",
     letterSpacing: 0.3,
-    textTransform: 'uppercase',
+    textTransform: "uppercase",
   },
 });

--- a/src/components/RecordingItem.tsx
+++ b/src/components/RecordingItem.tsx
@@ -1,32 +1,39 @@
-import { View, Text, Pressable, StyleSheet, Animated, useWindowDimensions } from 'react-native';
-import { Swipeable } from 'react-native-gesture-handler';
-import { useRef, useCallback } from 'react';
-import { useTranslation } from 'react-i18next';
-import type { Recording } from '../lib/recordings';
-import type { PlayState } from '../hooks/useRecordings';
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  Animated,
+  useWindowDimensions,
+} from "react-native";
+import { Swipeable } from "react-native-gesture-handler";
+import { useRef, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import type { Recording } from "../lib/recordings";
+import type { PlayState } from "../hooks/useRecordings";
 
 // Design tokens
 const colors = {
-  background: '#0A0A0B',
-  surface: '#141416',
-  surfaceElevated: '#1C1C1F',
-  border: '#2A2A2E',
-  textPrimary: '#FAFAFA',
-  textSecondary: '#A1A1AA',
-  textMuted: '#71717A',
-  accent: '#2DD4BF',
-  accentLight: 'rgba(45, 212, 191, 0.15)',
-  playing: '#5EEAD4',
-  playingLight: 'rgba(94, 234, 212, 0.15)',
-  danger: '#EF4444',
+  background: "#0A0A0B",
+  surface: "#141416",
+  surfaceElevated: "#1C1C1F",
+  border: "#2A2A2E",
+  textPrimary: "#FAFAFA",
+  textSecondary: "#A1A1AA",
+  textMuted: "#71717A",
+  accent: "#2DD4BF",
+  accentLight: "rgba(45, 212, 191, 0.15)",
+  playing: "#5EEAD4",
+  playingLight: "rgba(94, 234, 212, 0.15)",
+  danger: "#EF4444",
 };
 
 function formatDate(iso: string): string {
   const d = new Date(iso);
   return (
-    d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) +
-    ' at ' +
-    d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+    d.toLocaleDateString(undefined, { month: "short", day: "numeric" }) +
+    " at " +
+    d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })
   );
 }
 
@@ -34,7 +41,7 @@ function formatDuration(ms: number): string {
   const totalSec = Math.round(ms / 1000);
   const m = Math.floor(totalSec / 60);
   const s = totalSec % 60;
-  return `${m}:${String(s).padStart(2, '0')}`;
+  return `${m}:${String(s).padStart(2, "0")}`;
 }
 
 const ACTION_WIDTH = 88;
@@ -48,22 +55,34 @@ type Props = {
   disabled: boolean;
 };
 
-export function RecordingItem({ recording, playState, onTogglePlay, onDelete, disabled }: Props) {
+export function RecordingItem({
+  recording,
+  playState,
+  onTogglePlay,
+  onDelete,
+  disabled,
+}: Props) {
   const { t } = useTranslation();
-  const isPlaying = playState?.recordingId === recording.id && playState.isPlaying;
+  const isPlaying =
+    playState?.recordingId === recording.id && playState.isPlaying;
   const swipeableRef = useRef<Swipeable>(null);
   const { width: screenWidth } = useWindowDimensions();
   const transXRef = useRef<Animated.AnimatedInterpolation<number> | null>(null);
 
-  const handleSwipeableWillOpen = useCallback((direction: 'left' | 'right') => {
-    if (direction !== 'right') return;
-    const transX = transXRef.current;
-    if (!transX) return;
-    const value: number = (transX as ReturnType<typeof Animated.add> & { __getValue(): number }).__getValue();
-    if (value < -(screenWidth * FULL_SWIPE_RATIO)) {
-      onDelete();
-    }
-  }, [screenWidth, onDelete]);
+  const handleSwipeableWillOpen = useCallback(
+    (direction: "left" | "right") => {
+      if (direction !== "right") return;
+      const transX = transXRef.current;
+      if (!transX) return;
+      const value: number = (
+        transX as ReturnType<typeof Animated.add> & { __getValue(): number }
+      ).__getValue();
+      if (value < -(screenWidth * FULL_SWIPE_RATIO)) {
+        onDelete();
+      }
+    },
+    [screenWidth, onDelete],
+  );
 
   function renderRightActions(
     _progress: Animated.AnimatedInterpolation<number>,
@@ -74,11 +93,13 @@ export function RecordingItem({ recording, playState, onTogglePlay, onDelete, di
     const translateX = dragX.interpolate({
       inputRange: [-ACTION_WIDTH, 0],
       outputRange: [0, ACTION_WIDTH],
-      extrapolate: 'clamp',
+      extrapolate: "clamp",
     });
 
     return (
-      <Animated.View style={[styles.deleteAction, { transform: [{ translateX }] }]}>
+      <Animated.View
+        style={[styles.deleteAction, { transform: [{ translateX }] }]}
+      >
         <Pressable
           accessibilityLabel="delete-recording"
           onPress={() => {
@@ -90,7 +111,7 @@ export function RecordingItem({ recording, playState, onTogglePlay, onDelete, di
           <View style={styles.deleteIconContainer}>
             <Text style={styles.deleteIconText}>X</Text>
           </View>
-          <Text style={styles.deleteLabel}>{t('recordings.delete')}</Text>
+          <Text style={styles.deleteLabel}>{t("recordings.delete")}</Text>
         </Pressable>
       </Animated.View>
     );
@@ -105,9 +126,9 @@ export function RecordingItem({ recording, playState, onTogglePlay, onDelete, di
       onSwipeableWillOpen={handleSwipeableWillOpen}
       enabled={!disabled}
     >
-      <View 
-        style={[styles.row, isPlaying && styles.rowPlaying]} 
-        testID={`recording-row-${recording.id}`} 
+      <View
+        style={[styles.row, isPlaying && styles.rowPlaying]}
+        testID={`recording-row-${recording.id}`}
         accessibilityLabel={`recording-row-${recording.id}`}
       >
         <Pressable
@@ -116,15 +137,15 @@ export function RecordingItem({ recording, playState, onTogglePlay, onDelete, di
           onPress={onTogglePlay}
           disabled={disabled}
           style={({ pressed }) => [
-            styles.playButton, 
+            styles.playButton,
             isPlaying && styles.playButtonPlaying,
-            disabled && styles.playButtonDisabled, 
-            pressed && styles.playButtonPressed
+            disabled && styles.playButtonDisabled,
+            pressed && styles.playButtonPressed,
           ]}
           hitSlop={8}
         >
           <Text style={[styles.playIcon, isPlaying && styles.playIconPlaying]}>
-            {isPlaying ? '\u25A0' : '\u25B6'}
+            {isPlaying ? "\u25A0" : "\u25B6"}
           </Text>
         </Pressable>
         <View style={styles.meta}>
@@ -134,7 +155,9 @@ export function RecordingItem({ recording, playState, onTogglePlay, onDelete, di
             </Text>
           </View>
           <View style={styles.durationBadge}>
-            <Text style={styles.duration}>{formatDuration(recording.durationMs)}</Text>
+            <Text style={styles.duration}>
+              {formatDuration(recording.durationMs)}
+            </Text>
           </View>
         </View>
       </View>
@@ -144,8 +167,8 @@ export function RecordingItem({ recording, playState, onTogglePlay, onDelete, di
 
 const styles = StyleSheet.create({
   row: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     paddingVertical: 14,
     paddingHorizontal: 20,
     gap: 14,
@@ -161,8 +184,8 @@ const styles = StyleSheet.create({
     height: 44,
     borderRadius: 14,
     backgroundColor: colors.surfaceElevated,
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: "center",
+    justifyContent: "center",
     borderWidth: 1,
     borderColor: colors.border,
   },
@@ -172,27 +195,27 @@ const styles = StyleSheet.create({
   },
   playButtonDisabled: { opacity: 0.35 },
   playButtonPressed: { opacity: 0.7, transform: [{ scale: 0.95 }] },
-  playIcon: { 
-    color: colors.textSecondary, 
-    fontSize: 14, 
+  playIcon: {
+    color: colors.textSecondary,
+    fontSize: 14,
     lineHeight: 18,
   },
   playIconPlaying: {
     color: colors.textPrimary,
   },
-  meta: { 
-    flex: 1, 
-    flexDirection: 'row', 
-    justifyContent: 'space-between', 
-    alignItems: 'center' 
+  meta: {
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
   },
   metaLeft: {
     flex: 1,
   },
-  date: { 
-    fontSize: 14, 
+  date: {
+    fontSize: 14,
     color: colors.textPrimary,
-    fontWeight: '500',
+    fontWeight: "500",
   },
   textPlaying: {
     color: colors.playing,
@@ -205,41 +228,41 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: colors.border,
   },
-  duration: { 
-    fontSize: 13, 
-    color: colors.textMuted, 
-    fontVariant: ['tabular-nums'],
-    fontWeight: '600',
+  duration: {
+    fontSize: 13,
+    color: colors.textMuted,
+    fontVariant: ["tabular-nums"],
+    fontWeight: "600",
   },
   deleteAction: {
     width: ACTION_WIDTH,
     backgroundColor: colors.danger,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
   },
   deleteButton: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    width: '100%',
+    justifyContent: "center",
+    alignItems: "center",
+    width: "100%",
     gap: 6,
   },
   deleteIconContainer: {
     width: 32,
     height: 32,
     borderRadius: 10,
-    backgroundColor: 'rgba(255, 255, 255, 0.2)',
-    alignItems: 'center',
-    justifyContent: 'center',
+    backgroundColor: "rgba(255, 255, 255, 0.2)",
+    alignItems: "center",
+    justifyContent: "center",
   },
   deleteIconText: {
-    color: '#FFF',
+    color: "#FFF",
     fontSize: 14,
-    fontWeight: '700',
+    fontWeight: "700",
   },
   deleteLabel: {
-    color: '#FFF',
+    color: "#FFF",
     fontSize: 12,
-    fontWeight: '600',
+    fontWeight: "600",
   },
 });

--- a/src/components/RecordingsList.tsx
+++ b/src/components/RecordingsList.tsx
@@ -1,17 +1,17 @@
-import { FlatList, View, Text, StyleSheet } from 'react-native';
-import { useTranslation } from 'react-i18next';
-import type { Recording } from '../lib/recordings';
-import type { PlayState } from '../hooks/useRecordings';
-import { RecordingItem } from './RecordingItem';
+import { FlatList, View, Text, StyleSheet } from "react-native";
+import { useTranslation } from "react-i18next";
+import type { Recording } from "../lib/recordings";
+import type { PlayState } from "../hooks/useRecordings";
+import { RecordingItem } from "./RecordingItem";
 
 // Design tokens
 const colors = {
-  background: '#0A0A0B',
-  surface: '#141416',
-  surfaceElevated: '#1C1C1F',
-  border: '#2A2A2E',
-  textMuted: '#71717A',
-  accent: '#2DD4BF',
+  background: "#0A0A0B",
+  surface: "#141416",
+  surfaceElevated: "#1C1C1F",
+  border: "#2A2A2E",
+  textMuted: "#71717A",
+  accent: "#2DD4BF",
 };
 
 type Props = {
@@ -22,7 +22,13 @@ type Props = {
   disabled: boolean;
 };
 
-export function RecordingsList({ recordings, playState, onTogglePlay, onDelete, disabled }: Props) {
+export function RecordingsList({
+  recordings,
+  playState,
+  onTogglePlay,
+  onDelete,
+  disabled,
+}: Props) {
   const { t } = useTranslation();
 
   if (recordings.length === 0) {
@@ -34,8 +40,10 @@ export function RecordingsList({ recordings, playState, onTogglePlay, onDelete, 
           <View style={styles.emptyIconBar2} />
           <View style={styles.emptyIconBar3} />
         </View>
-        <Text style={styles.emptyText}>{t('recordings.empty')}</Text>
-        <Text style={styles.emptyHint}>{t('recordings.empty_hint') || 'Start speaking to record'}</Text>
+        <Text style={styles.emptyText}>{t("recordings.empty")}</Text>
+        <Text style={styles.emptyHint}>
+          {t("recordings.empty_hint") || "Start speaking to record"}
+        </Text>
       </View>
     );
   }
@@ -43,7 +51,7 @@ export function RecordingsList({ recordings, playState, onTogglePlay, onDelete, 
   return (
     <FlatList
       data={recordings}
-      keyExtractor={item => item.id}
+      keyExtractor={(item) => item.id}
       renderItem={({ item }) => (
         <RecordingItem
           recording={item}
@@ -61,25 +69,25 @@ export function RecordingsList({ recordings, playState, onTogglePlay, onDelete, 
 }
 
 const styles = StyleSheet.create({
-  list: { 
+  list: {
     flex: 1,
   },
   listContent: {
     paddingBottom: 24,
   },
-  empty: { 
-    flex: 1, 
-    alignItems: 'center', 
-    justifyContent: 'center',
+  empty: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
     paddingVertical: 48,
     gap: 12,
   },
   emptyIconContainer: {
     width: 64,
     height: 48,
-    flexDirection: 'row',
-    alignItems: 'flex-end',
-    justifyContent: 'center',
+    flexDirection: "row",
+    alignItems: "flex-end",
+    justifyContent: "center",
     gap: 4,
     marginBottom: 8,
   },
@@ -107,10 +115,10 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     backgroundColor: colors.border,
   },
-  emptyText: { 
-    color: colors.textMuted, 
+  emptyText: {
+    color: colors.textMuted,
     fontSize: 15,
-    fontWeight: '600',
+    fontWeight: "600",
   },
   emptyHint: {
     color: colors.border,

--- a/src/components/__tests__/AudioLevelMeter.test.tsx
+++ b/src/components/__tests__/AudioLevelMeter.test.tsx
@@ -1,20 +1,20 @@
-import { render } from '@testing-library/react-native';
-import { Rect, Line } from 'react-native-svg';
-import { AudioLevelMeter, BAR_WIDTH } from '../AudioLevelMeter';
-import { LEVEL_HISTORY_SIZE } from '../../constants/audio';
-import type { Phase } from '../../hooks/types';
+import { render } from "@testing-library/react-native";
+import { Rect, Line } from "react-native-svg";
+import { AudioLevelMeter, BAR_WIDTH } from "../AudioLevelMeter";
+import { LEVEL_HISTORY_SIZE } from "../../constants/audio";
+import type { Phase } from "../../hooks/types";
 
 const makeHistory = (size = LEVEL_HISTORY_SIZE) => new Array(size).fill(0);
 
 const defaultProps = {
   history: makeHistory(),
-  phase: 'idle' as Phase,
+  phase: "idle" as Phase,
   currentDb: -40,
   voiceThresholdDb: -35,
   silenceThresholdDb: -45,
 };
 
-describe('AudioLevelMeter', () => {
+describe("AudioLevelMeter", () => {
   it(`renders ${LEVEL_HISTORY_SIZE} bars`, () => {
     const { UNSAFE_getAllByType } = render(
       <AudioLevelMeter {...defaultProps} />,
@@ -25,12 +25,14 @@ describe('AudioLevelMeter', () => {
     expect(bars).toHaveLength(LEVEL_HISTORY_SIZE);
   });
 
-  const phases: Phase[] = ['idle', 'recording', 'playing', 'paused'];
+  const phases: Phase[] = ["idle", "recording", "playing", "paused"];
   it.each(phases)('renders without crashing for phase "%s"', (phase) => {
-    expect(() => render(<AudioLevelMeter {...defaultProps} phase={phase} />)).not.toThrow();
+    expect(() =>
+      render(<AudioLevelMeter {...defaultProps} phase={phase} />),
+    ).not.toThrow();
   });
 
-  it('renders guide lines during idle phase', () => {
+  it("renders guide lines during idle phase", () => {
     const { UNSAFE_getAllByType } = render(
       <AudioLevelMeter {...defaultProps} phase="idle" />,
     );
@@ -38,7 +40,7 @@ describe('AudioLevelMeter', () => {
     expect(lines).toHaveLength(2);
   });
 
-  it('renders guide lines during recording phase', () => {
+  it("renders guide lines during recording phase", () => {
     const { UNSAFE_getAllByType } = render(
       <AudioLevelMeter {...defaultProps} phase="recording" />,
     );
@@ -46,28 +48,28 @@ describe('AudioLevelMeter', () => {
     expect(lines).toHaveLength(2);
   });
 
-  it('hides guide lines during playing phase', () => {
+  it("hides guide lines during playing phase", () => {
     const { UNSAFE_getAllByType } = render(
       <AudioLevelMeter {...defaultProps} phase="playing" />,
     );
     expect(() => UNSAFE_getAllByType(Line)).toThrow();
   });
 
-  it('hides guide lines during paused phase', () => {
+  it("hides guide lines during paused phase", () => {
     const { UNSAFE_getAllByType } = render(
       <AudioLevelMeter {...defaultProps} phase="paused" />,
     );
     expect(() => UNSAFE_getAllByType(Line)).toThrow();
   });
 
-  it('shows dB label when currentDb is provided and phase is idle', () => {
+  it("shows dB label when currentDb is provided and phase is idle", () => {
     const { getByText } = render(
       <AudioLevelMeter {...defaultProps} phase="idle" currentDb={-42} />,
     );
-    expect(getByText('-42 dB')).toBeTruthy();
+    expect(getByText("-42 dB")).toBeTruthy();
   });
 
-  it('hides dB label when currentDb is null', () => {
+  it("hides dB label when currentDb is null", () => {
     const { queryByText } = render(
       <AudioLevelMeter {...defaultProps} phase="idle" currentDb={null} />,
     );

--- a/src/components/__tests__/PhaseDisplay.test.tsx
+++ b/src/components/__tests__/PhaseDisplay.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react-native';
-import { I18nextProvider } from 'react-i18next';
-import { setupTestI18n } from '../../__tests__/helpers/setupI18n';
-import { PhaseDisplay } from '../PhaseDisplay';
+import { render, screen } from "@testing-library/react-native";
+import { I18nextProvider } from "react-i18next";
+import { setupTestI18n } from "../../__tests__/helpers/setupI18n";
+import { PhaseDisplay } from "../PhaseDisplay";
 
 const i18n = setupTestI18n();
 
@@ -9,24 +9,24 @@ function renderWithI18n(ui: React.ReactElement) {
   return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>);
 }
 
-describe('PhaseDisplay', () => {
+describe("PhaseDisplay", () => {
   it('shows "Listening…" in idle phase', () => {
     renderWithI18n(<PhaseDisplay phase="idle" />);
-    expect(screen.getByText('Listening…')).toBeTruthy();
+    expect(screen.getByText("Listening…")).toBeTruthy();
   });
 
   it('shows "Recording" in recording phase', () => {
     renderWithI18n(<PhaseDisplay phase="recording" />);
-    expect(screen.getByText('Recording')).toBeTruthy();
+    expect(screen.getByText("Recording")).toBeTruthy();
   });
 
   it('shows "Playing back" in playing phase', () => {
     renderWithI18n(<PhaseDisplay phase="playing" />);
-    expect(screen.getByText('Playing back')).toBeTruthy();
+    expect(screen.getByText("Playing back")).toBeTruthy();
   });
 
   it('shows "Paused" in paused phase', () => {
     renderWithI18n(<PhaseDisplay phase="paused" />);
-    expect(screen.getByText('Paused')).toBeTruthy();
+    expect(screen.getByText("Paused")).toBeTruthy();
   });
 });

--- a/src/components/__tests__/RecordingItem.test.tsx
+++ b/src/components/__tests__/RecordingItem.test.tsx
@@ -1,11 +1,11 @@
-import { render, screen, fireEvent } from '@testing-library/react-native';
-import { I18nextProvider } from 'react-i18next';
-import { setupTestI18n } from '../../__tests__/helpers/setupI18n';
-import { RecordingItem } from '../RecordingItem';
-import type { Recording } from '../../lib/recordings';
+import { render, screen, fireEvent } from "@testing-library/react-native";
+import { I18nextProvider } from "react-i18next";
+import { setupTestI18n } from "../../__tests__/helpers/setupI18n";
+import { RecordingItem } from "../RecordingItem";
+import type { Recording } from "../../lib/recordings";
 
-jest.mock('react-native-gesture-handler', () => {
-  const RN = jest.requireActual<typeof import('react-native')>('react-native');
+jest.mock("react-native-gesture-handler", () => {
+  const RN = jest.requireActual<typeof import("react-native")>("react-native");
   return {
     Swipeable: RN.View,
     GestureHandlerRootView: RN.View,
@@ -15,14 +15,16 @@ jest.mock('react-native-gesture-handler', () => {
 const i18n = setupTestI18n();
 
 const makeRecording = (overrides?: Partial<Recording>): Recording => ({
-  id: '1',
-  filePath: 'file:///tmp/recording_1.m4a',
-  recordedAt: '2026-03-22T10:30:00.000Z',
+  id: "1",
+  filePath: "file:///tmp/recording_1.m4a",
+  recordedAt: "2026-03-22T10:30:00.000Z",
   durationMs: 75000,
   ...overrides,
 });
 
-function renderItem(props: Partial<React.ComponentProps<typeof RecordingItem>> = {}) {
+function renderItem(
+  props: Partial<React.ComponentProps<typeof RecordingItem>> = {},
+) {
   const defaultProps: React.ComponentProps<typeof RecordingItem> = {
     recording: makeRecording(),
     playState: null,
@@ -38,48 +40,48 @@ function renderItem(props: Partial<React.ComponentProps<typeof RecordingItem>> =
   );
 }
 
-describe('RecordingItem', () => {
-  it('shows play icon when not playing', () => {
+describe("RecordingItem", () => {
+  it("shows play icon when not playing", () => {
     renderItem();
-    expect(screen.getByText('▶')).toBeTruthy();
+    expect(screen.getByText("▶")).toBeTruthy();
   });
 
-  it('shows stop icon when this recording is playing', () => {
+  it("shows stop icon when this recording is playing", () => {
     renderItem({
-      recording: makeRecording({ id: '1' }),
-      playState: { recordingId: '1', isPlaying: true },
+      recording: makeRecording({ id: "1" }),
+      playState: { recordingId: "1", isPlaying: true },
     });
-    expect(screen.getByText('■')).toBeTruthy();
+    expect(screen.getByText("■")).toBeTruthy();
   });
 
-  it('shows play icon when a different recording is playing', () => {
+  it("shows play icon when a different recording is playing", () => {
     renderItem({
-      recording: makeRecording({ id: '1' }),
-      playState: { recordingId: '2', isPlaying: true },
+      recording: makeRecording({ id: "1" }),
+      playState: { recordingId: "2", isPlaying: true },
     });
-    expect(screen.getByText('▶')).toBeTruthy();
+    expect(screen.getByText("▶")).toBeTruthy();
   });
 
-  it('displays a formatted duration', () => {
+  it("displays a formatted duration", () => {
     renderItem({ recording: makeRecording({ durationMs: 75000 }) });
-    expect(screen.getByText('1:15')).toBeTruthy();
+    expect(screen.getByText("1:15")).toBeTruthy();
   });
 
-  it('calls onTogglePlay when button is pressed', () => {
+  it("calls onTogglePlay when button is pressed", () => {
     const onTogglePlay = jest.fn();
     renderItem({ onTogglePlay });
-    fireEvent.press(screen.getByText('▶'));
+    fireEvent.press(screen.getByText("▶"));
     expect(onTogglePlay).toHaveBeenCalledTimes(1);
   });
 
-  it('does not call onTogglePlay when disabled', () => {
+  it("does not call onTogglePlay when disabled", () => {
     const onTogglePlay = jest.fn();
     renderItem({ onTogglePlay, disabled: true });
-    fireEvent.press(screen.getByText('▶'));
+    fireEvent.press(screen.getByText("▶"));
     expect(onTogglePlay).not.toHaveBeenCalled();
   });
 
-  it('renders without crashing with onDelete prop', () => {
+  it("renders without crashing with onDelete prop", () => {
     renderItem();
   });
 });

--- a/src/context/AudioContextProvider.tsx
+++ b/src/context/AudioContextProvider.tsx
@@ -1,20 +1,26 @@
-import { createContext, useContext, useEffect, useState } from 'react';
-import { AudioContext } from 'react-native-audio-api';
-import { addBreadcrumb } from '../lib/sentryHelpers';
+import { createContext, useContext, useEffect, useState } from "react";
+import { AudioContext } from "react-native-audio-api";
+import { addBreadcrumb } from "../lib/sentryHelpers";
 
 const Ctx = createContext<AudioContext | null>(null);
 
-export function AudioContextProvider({ children }: { children: React.ReactNode }) {
+export function AudioContextProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   const [ctx, setCtx] = useState<AudioContext | null>(null);
 
   useEffect(() => {
     // Omit sampleRate to use device-native rate and avoid resampling click artifacts
     const context = new AudioContext();
-    addBreadcrumb('audio', 'AudioContext created', {
+    addBreadcrumb("audio", "AudioContext created", {
       sampleRate: context.sampleRate,
     });
     setCtx(context);
-    return () => { void context.close(); };
+    return () => {
+      void context.close();
+    };
   }, []);
 
   return <Ctx.Provider value={ctx}>{children}</Ctx.Provider>;

--- a/src/context/ServicesProvider.tsx
+++ b/src/context/ServicesProvider.tsx
@@ -1,8 +1,8 @@
-import { createContext, useContext } from 'react';
-import type { IAudioRecordingService } from '../services/AudioRecordingService';
-import type { IAudioEncoderService } from '../services/AudioEncoderService';
-import type { IAudioDecoderService } from '../services/AudioDecoderService';
-import type { IRecordingsRepository } from '../repositories/RecordingsRepository';
+import { createContext, useContext } from "react";
+import type { IAudioRecordingService } from "../services/AudioRecordingService";
+import type { IAudioEncoderService } from "../services/AudioEncoderService";
+import type { IAudioDecoderService } from "../services/AudioDecoderService";
+import type { IRecordingsRepository } from "../repositories/RecordingsRepository";
 
 export type Services = {
   recordingService: IAudioRecordingService;
@@ -20,11 +20,13 @@ export function ServicesProvider({
   children: React.ReactNode;
   services: Services;
 }) {
-  return <ServicesCtx.Provider value={services}>{children}</ServicesCtx.Provider>;
+  return (
+    <ServicesCtx.Provider value={services}>{children}</ServicesCtx.Provider>
+  );
 }
 
 export function useServices(): Services {
   const ctx = useContext(ServicesCtx);
-  if (!ctx) throw new Error('useServices must be used inside ServicesProvider');
+  if (!ctx) throw new Error("useServices must be used inside ServicesProvider");
   return ctx;
 }

--- a/src/context/SettingsProvider.tsx
+++ b/src/context/SettingsProvider.tsx
@@ -1,7 +1,13 @@
-import { createContext, useContext, useState, useEffect, useCallback } from 'react';
-import { type AppSettings, DEFAULT_SETTINGS } from '../types/settings';
-import type { ISettingsRepository } from '../repositories/SettingsRepository';
-import { captureException } from '../lib/sentryHelpers';
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+} from "react";
+import { type AppSettings, DEFAULT_SETTINGS } from "../types/settings";
+import type { ISettingsRepository } from "../repositories/SettingsRepository";
+import { captureException } from "../lib/sentryHelpers";
 
 type SettingsContextValue = {
   settings: AppSettings;
@@ -26,15 +32,18 @@ export function SettingsProvider({
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
-    repository.load().then((s) => {
-      setSettings(s);
-      setLoaded(true);
-    }).catch((e) => {
-      captureException(e, {
-        operation: 'SettingsRepository.load',
+    repository
+      .load()
+      .then((s) => {
+        setSettings(s);
+        setLoaded(true);
+      })
+      .catch((e) => {
+        captureException(e, {
+          operation: "SettingsRepository.load",
+        });
+        setLoaded(true);
       });
-      setLoaded(true);
-    });
   }, [repository]);
 
   const updateSetting = useCallback(
@@ -42,7 +51,7 @@ export function SettingsProvider({
       setSettings((prev) => ({ ...prev, [key]: value }));
       repository.save(key, value).catch((e) => {
         captureException(e, {
-          operation: 'SettingsRepository.save',
+          operation: "SettingsRepository.save",
           key,
           value,
         });
@@ -55,13 +64,15 @@ export function SettingsProvider({
     setSettings(DEFAULT_SETTINGS);
     repository.resetAll().catch((e) => {
       captureException(e, {
-        operation: 'SettingsRepository.resetAll',
+        operation: "SettingsRepository.resetAll",
       });
     });
   }, [repository]);
 
   return (
-    <SettingsCtx.Provider value={{ settings, loaded, updateSetting, resetSettings }}>
+    <SettingsCtx.Provider
+      value={{ settings, loaded, updateSetting, resetSettings }}
+    >
       {children}
     </SettingsCtx.Provider>
   );
@@ -69,6 +80,6 @@ export function SettingsProvider({
 
 export function useSettings(): SettingsContextValue {
   const ctx = useContext(SettingsCtx);
-  if (!ctx) throw new Error('useSettings must be used inside SettingsProvider');
+  if (!ctx) throw new Error("useSettings must be used inside SettingsProvider");
   return ctx;
 }

--- a/src/hooks/__tests__/usePlaybackLevelHistory.test.ts
+++ b/src/hooks/__tests__/usePlaybackLevelHistory.test.ts
@@ -1,7 +1,7 @@
-import { renderHook, act } from '@testing-library/react-native';
-import { usePlaybackLevelHistory } from '../usePlaybackLevelHistory';
-import { makeStubAudioBuffer } from '../../__tests__/stubs/stubAudioDecoderService';
-import { LEVEL_HISTORY_SIZE } from '../../constants/audio';
+import { renderHook, act } from "@testing-library/react-native";
+import { usePlaybackLevelHistory } from "../usePlaybackLevelHistory";
+import { makeStubAudioBuffer } from "../../__tests__/stubs/stubAudioDecoderService";
+import { LEVEL_HISTORY_SIZE } from "../../constants/audio";
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -18,8 +18,8 @@ function makeLoudAudioBuffer(length = 44100, sampleRate = 44100) {
   return buffer;
 }
 
-describe('usePlaybackLevelHistory', () => {
-  it('startPlaybackLevels begins pushing values into levelHistory via the setter', () => {
+describe("usePlaybackLevelHistory", () => {
+  it("startPlaybackLevels begins pushing values into levelHistory via the setter", () => {
     const { result } = renderHook(() => usePlaybackLevelHistory());
     const history: number[] = new Array(LEVEL_HISTORY_SIZE).fill(0);
     const setLevelHistory = jest.fn((updater: (prev: number[]) => number[]) => {
@@ -29,52 +29,80 @@ describe('usePlaybackLevelHistory', () => {
     });
 
     act(() => {
-      result.current.startPlaybackLevels(makeLoudAudioBuffer(), 0, setLevelHistory);
+      result.current.startPlaybackLevels(
+        makeLoudAudioBuffer(),
+        0,
+        setLevelHistory,
+      );
     });
 
     // Initial reset call
     expect(setLevelHistory).toHaveBeenCalledTimes(1);
 
-    act(() => { jest.advanceTimersByTime(93); });
+    act(() => {
+      jest.advanceTimersByTime(93);
+    });
 
     expect(setLevelHistory).toHaveBeenCalledTimes(2);
     expect(history[history.length - 1]).toBeGreaterThan(0);
   });
 
-  it('stopPlaybackLevels stops the timer (no further updates)', () => {
+  it("stopPlaybackLevels stops the timer (no further updates)", () => {
     const { result } = renderHook(() => usePlaybackLevelHistory());
     const setLevelHistory = jest.fn();
 
     act(() => {
-      result.current.startPlaybackLevels(makeLoudAudioBuffer(), 0, setLevelHistory);
+      result.current.startPlaybackLevels(
+        makeLoudAudioBuffer(),
+        0,
+        setLevelHistory,
+      );
     });
 
-    act(() => { jest.advanceTimersByTime(93); });
+    act(() => {
+      jest.advanceTimersByTime(93);
+    });
     const callCountAfterOneTick = setLevelHistory.mock.calls.length;
 
-    act(() => { result.current.stopPlaybackLevels(); });
-    act(() => { jest.advanceTimersByTime(93 * 5); });
+    act(() => {
+      result.current.stopPlaybackLevels();
+    });
+    act(() => {
+      jest.advanceTimersByTime(93 * 5);
+    });
 
     expect(setLevelHistory).toHaveBeenCalledTimes(callCountAfterOneTick);
   });
 
-  it('calling startPlaybackLevels twice stops the first timer before starting a new one', () => {
+  it("calling startPlaybackLevels twice stops the first timer before starting a new one", () => {
     const { result } = renderHook(() => usePlaybackLevelHistory());
     const setLevelHistory1 = jest.fn();
     const setLevelHistory2 = jest.fn();
 
     act(() => {
-      result.current.startPlaybackLevels(makeLoudAudioBuffer(), 0, setLevelHistory1);
+      result.current.startPlaybackLevels(
+        makeLoudAudioBuffer(),
+        0,
+        setLevelHistory1,
+      );
     });
 
-    act(() => { jest.advanceTimersByTime(93); });
+    act(() => {
+      jest.advanceTimersByTime(93);
+    });
     const callsAfterFirstTick = setLevelHistory1.mock.calls.length;
 
     act(() => {
-      result.current.startPlaybackLevels(makeLoudAudioBuffer(), 0, setLevelHistory2);
+      result.current.startPlaybackLevels(
+        makeLoudAudioBuffer(),
+        0,
+        setLevelHistory2,
+      );
     });
 
-    act(() => { jest.advanceTimersByTime(93); });
+    act(() => {
+      jest.advanceTimersByTime(93);
+    });
 
     // First setter should not have been called again after second start
     expect(setLevelHistory1).toHaveBeenCalledTimes(callsAfterFirstTick);
@@ -82,7 +110,7 @@ describe('usePlaybackLevelHistory', () => {
     expect(setLevelHistory2.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('auto-stops when reaching the end of the audio buffer', () => {
+  it("auto-stops when reaching the end of the audio buffer", () => {
     const shortBuffer = makeLoudAudioBuffer(4096, 44100); // ~93ms of audio
     const { result } = renderHook(() => usePlaybackLevelHistory());
     const setLevelHistory = jest.fn();
@@ -92,12 +120,16 @@ describe('usePlaybackLevelHistory', () => {
     });
 
     // Advance well past the buffer duration
-    act(() => { jest.advanceTimersByTime(93 * 10); });
+    act(() => {
+      jest.advanceTimersByTime(93 * 10);
+    });
 
     const callCount = setLevelHistory.mock.calls.length;
 
     // Further ticks should produce no additional calls
-    act(() => { jest.advanceTimersByTime(93 * 5); });
+    act(() => {
+      jest.advanceTimersByTime(93 * 5);
+    });
     expect(setLevelHistory).toHaveBeenCalledTimes(callCount);
   });
 });

--- a/src/hooks/__tests__/useRecordings.test.ts
+++ b/src/hooks/__tests__/useRecordings.test.ts
@@ -1,22 +1,28 @@
-jest.mock('../../lib/sentryHelpers', () => ({
+jest.mock("../../lib/sentryHelpers", () => ({
   captureException: jest.fn(),
   captureMessage: jest.fn(),
   addBreadcrumb: jest.fn(),
 }));
 
-import { renderHook, act, waitFor } from '@testing-library/react-native';
-import { useRecordings } from '../useRecordings';
-import { StubRecordingsRepository } from '../../__tests__/stubs/stubRecordingsRepository';
-import { StubAudioDecoderService, makeStubAudioBuffer } from '../../__tests__/stubs/stubAudioDecoderService';
-import { makeStubAudioContext, makeStubBufferSourceNode } from '../../__tests__/stubs/stubAudioContext';
-import { LEVEL_HISTORY_SIZE } from '../../constants/audio';
-import type { Recording } from '../../lib/recordings';
+import { renderHook, act, waitFor } from "@testing-library/react-native";
+import { useRecordings } from "../useRecordings";
+import { StubRecordingsRepository } from "../../__tests__/stubs/stubRecordingsRepository";
+import {
+  StubAudioDecoderService,
+  makeStubAudioBuffer,
+} from "../../__tests__/stubs/stubAudioDecoderService";
+import {
+  makeStubAudioContext,
+  makeStubBufferSourceNode,
+} from "../../__tests__/stubs/stubAudioContext";
+import { LEVEL_HISTORY_SIZE } from "../../constants/audio";
+import type { Recording } from "../../lib/recordings";
 
 function makeRecording(overrides?: Partial<Recording>): Recording {
   return {
-    id: '1',
-    filePath: 'file:///tmp/recording_1.m4a',
-    recordedAt: '2026-03-22T10:00:00.000Z',
+    id: "1",
+    filePath: "file:///tmp/recording_1.m4a",
+    recordedAt: "2026-03-22T10:00:00.000Z",
     durationMs: 2000,
     ...overrides,
   };
@@ -31,68 +37,91 @@ function setup(initialRecordings: Recording[] = [], maxRecordings = 0) {
   const onDidStop = jest.fn().mockResolvedValue(undefined);
 
   const { result } = renderHook(() =>
-    useRecordings({ onWillPlay, onDidStop }, audioContext, repository, decoderService, maxRecordings),
+    useRecordings(
+      { onWillPlay, onDidStop },
+      audioContext,
+      repository,
+      decoderService,
+      maxRecordings,
+    ),
   );
 
-  return { result, repository, decoderService, audioContext, onWillPlay, onDidStop };
+  return {
+    result,
+    repository,
+    decoderService,
+    audioContext,
+    onWillPlay,
+    onDidStop,
+  };
 }
 
-describe('useRecordings — initial load', () => {
-  it('loads saved recordings from repository on mount', async () => {
-    const initial = [makeRecording({ id: '1' }), makeRecording({ id: '2' })];
+describe("useRecordings — initial load", () => {
+  it("loads saved recordings from repository on mount", async () => {
+    const initial = [makeRecording({ id: "1" }), makeRecording({ id: "2" })];
     const { result } = setup(initial);
     await waitFor(() => expect(result.current.recordings).toHaveLength(2));
   });
 });
 
-describe('useRecordings — addRecording', () => {
-  it('prepends the new entry to the recordings list', async () => {
-    const { result } = setup([makeRecording({ id: 'existing' })]);
+describe("useRecordings — addRecording", () => {
+  it("prepends the new entry to the recordings list", async () => {
+    const { result } = setup([makeRecording({ id: "existing" })]);
     await waitFor(() => expect(result.current.recordings).toHaveLength(1));
 
-    act(() => { result.current.addRecording('/tmp/new.m4a', 1500); });
+    act(() => {
+      result.current.addRecording("/tmp/new.m4a", 1500);
+    });
 
     expect(result.current.recordings).toHaveLength(2);
     expect(result.current.recordings[0].durationMs).toBe(1500);
   });
 
-  it('adds file:// prefix to the filePath', async () => {
+  it("adds file:// prefix to the filePath", async () => {
     const { result } = setup();
     await waitFor(() => expect(result.current.recordings).toHaveLength(0));
 
-    act(() => { result.current.addRecording('/tmp/new.m4a', 1000); });
+    act(() => {
+      result.current.addRecording("/tmp/new.m4a", 1000);
+    });
 
-    expect(result.current.recordings[0].filePath).toBe('file:///tmp/new.m4a');
+    expect(result.current.recordings[0].filePath).toBe("file:///tmp/new.m4a");
   });
 
-  it('calls repository.save with the updated list', async () => {
+  it("calls repository.save with the updated list", async () => {
     const { result, repository } = setup();
     await waitFor(() => expect(result.current.recordings).toHaveLength(0));
 
-    act(() => { result.current.addRecording('/tmp/new.m4a', 1000); });
+    act(() => {
+      result.current.addRecording("/tmp/new.m4a", 1000);
+    });
 
     expect(repository.save).toHaveBeenCalledTimes(1);
     expect(repository.save.mock.calls[0][0]).toHaveLength(1);
   });
 });
 
-describe('useRecordings — togglePlay', () => {
-  it('calls onWillPlay before starting playback', async () => {
+describe("useRecordings — togglePlay", () => {
+  it("calls onWillPlay before starting playback", async () => {
     const recording = makeRecording();
     const { result, onWillPlay } = setup([recording]);
     await waitFor(() => expect(result.current.recordings).toHaveLength(1));
 
-    await act(async () => { result.current.togglePlay(recording); });
+    await act(async () => {
+      result.current.togglePlay(recording);
+    });
 
     expect(onWillPlay).toHaveBeenCalledTimes(1);
   });
 
-  it('decodes the file with the correct filePath and sampleRate', async () => {
+  it("decodes the file with the correct filePath and sampleRate", async () => {
     const recording = makeRecording();
     const { result, decoderService, audioContext } = setup([recording]);
     await waitFor(() => expect(result.current.recordings).toHaveLength(1));
 
-    await act(async () => { result.current.togglePlay(recording); });
+    await act(async () => {
+      result.current.togglePlay(recording);
+    });
 
     expect(decoderService.decodeAudioData).toHaveBeenCalledWith(
       recording.filePath,
@@ -100,244 +129,337 @@ describe('useRecordings — togglePlay', () => {
     );
   });
 
-  it('sets playState to isPlaying for the recording', async () => {
-    const recording = makeRecording({ id: 'r1' });
+  it("sets playState to isPlaying for the recording", async () => {
+    const recording = makeRecording({ id: "r1" });
     const { result } = setup([recording]);
     await waitFor(() => expect(result.current.recordings).toHaveLength(1));
 
-    await act(async () => { result.current.togglePlay(recording); });
+    await act(async () => {
+      result.current.togglePlay(recording);
+    });
 
-    expect(result.current.playState).toEqual({ recordingId: 'r1', isPlaying: true });
+    expect(result.current.playState).toEqual({
+      recordingId: "r1",
+      isPlaying: true,
+    });
   });
 
-  it('stops playback and calls onDidStop when toggled again while playing', async () => {
-    const recording = makeRecording({ id: 'r1' });
+  it("stops playback and calls onDidStop when toggled again while playing", async () => {
+    const recording = makeRecording({ id: "r1" });
     const { result, onDidStop } = setup([recording]);
     await waitFor(() => expect(result.current.recordings).toHaveLength(1));
 
-    await act(async () => { result.current.togglePlay(recording); });
-    act(() => { result.current.togglePlay(recording); });
+    await act(async () => {
+      result.current.togglePlay(recording);
+    });
+    act(() => {
+      result.current.togglePlay(recording);
+    });
 
     expect(onDidStop).toHaveBeenCalledTimes(1);
     expect(result.current.playState).toBeNull();
   });
 
-  it('is a no-op while decoding is in progress', async () => {
+  it("is a no-op while decoding is in progress", async () => {
     const recording = makeRecording();
     const { result, decoderService, onWillPlay } = setup([recording]);
     await waitFor(() => expect(result.current.recordings).toHaveLength(1));
 
-    let resolveDecoding!: (value: Awaited<ReturnType<typeof decoderService.decodeAudioData>>) => void;
+    let resolveDecoding!: (
+      value: Awaited<ReturnType<typeof decoderService.decodeAudioData>>,
+    ) => void;
     decoderService.decodeAudioData.mockImplementation(
-      () => new Promise(resolve => { resolveDecoding = resolve; }),
+      () =>
+        new Promise((resolve) => {
+          resolveDecoding = resolve;
+        }),
     );
 
     // First call: flush past onWillPlay so isDecodingRef becomes true, but decoding stays pending
-    await act(async () => { result.current.togglePlay(recording); });
+    await act(async () => {
+      result.current.togglePlay(recording);
+    });
     // Second call: should be blocked by isDecodingRef guard
-    await act(async () => { result.current.togglePlay(recording); });
+    await act(async () => {
+      result.current.togglePlay(recording);
+    });
 
     expect(onWillPlay).toHaveBeenCalledTimes(1);
     expect(decoderService.decodeAudioData).toHaveBeenCalledTimes(1);
 
-    await act(async () => { resolveDecoding(makeStubAudioBuffer()); });
+    await act(async () => {
+      resolveDecoding(makeStubAudioBuffer());
+    });
   });
 
-  it('calls onDidStop and clears playState when decodeAudioData rejects', async () => {
+  it("calls onDidStop and clears playState when decodeAudioData rejects", async () => {
     const recording = makeRecording();
     const { result, decoderService, onDidStop } = setup([recording]);
     await waitFor(() => expect(result.current.recordings).toHaveLength(1));
 
-    decoderService.decodeAudioData.mockRejectedValueOnce(new Error('decode failed'));
+    decoderService.decodeAudioData.mockRejectedValueOnce(
+      new Error("decode failed"),
+    );
 
-    await act(async () => { result.current.togglePlay(recording); });
+    await act(async () => {
+      result.current.togglePlay(recording);
+    });
 
     expect(onDidStop).toHaveBeenCalledTimes(1);
     expect(result.current.playState).toBeNull();
   });
 });
 
-describe('useRecordings — source node onEnded', () => {
-  it('clears playState and calls onDidStop when playback ends naturally', async () => {
-    const recording = makeRecording({ id: 'r1' });
+describe("useRecordings — source node onEnded", () => {
+  it("clears playState and calls onDidStop when playback ends naturally", async () => {
+    const recording = makeRecording({ id: "r1" });
     const { result, audioContext, onDidStop } = setup([recording]);
     await waitFor(() => expect(result.current.recordings).toHaveLength(1));
 
     const stubSource = makeStubBufferSourceNode();
-    (audioContext.createBufferSource as jest.Mock).mockReturnValueOnce(stubSource);
+    (audioContext.createBufferSource as jest.Mock).mockReturnValueOnce(
+      stubSource,
+    );
 
-    await act(async () => { result.current.togglePlay(recording); });
-    expect(result.current.playState).toEqual({ recordingId: 'r1', isPlaying: true });
+    await act(async () => {
+      result.current.togglePlay(recording);
+    });
+    expect(result.current.playState).toEqual({
+      recordingId: "r1",
+      isPlaying: true,
+    });
 
-    act(() => { stubSource.onEnded?.(); });
+    act(() => {
+      stubSource.onEnded?.();
+    });
 
     expect(result.current.playState).toBeNull();
     expect(onDidStop).toHaveBeenCalledTimes(1);
   });
 });
 
-describe('useRecordings — deleteRecording', () => {
-  it('removes the recording from the list', async () => {
-    const r1 = makeRecording({ id: '1' });
-    const r2 = makeRecording({ id: '2', filePath: 'file:///tmp/recording_2.m4a' });
+describe("useRecordings — deleteRecording", () => {
+  it("removes the recording from the list", async () => {
+    const r1 = makeRecording({ id: "1" });
+    const r2 = makeRecording({
+      id: "2",
+      filePath: "file:///tmp/recording_2.m4a",
+    });
     const { result } = setup([r1, r2]);
     await waitFor(() => expect(result.current.recordings).toHaveLength(2));
 
-    act(() => { result.current.deleteRecording('1'); });
+    act(() => {
+      result.current.deleteRecording("1");
+    });
 
     expect(result.current.recordings).toHaveLength(1);
-    expect(result.current.recordings[0].id).toBe('2');
+    expect(result.current.recordings[0].id).toBe("2");
   });
 
-  it('calls repository.deleteFile with the path (file:// stripped)', async () => {
-    const r = makeRecording({ id: '1', filePath: 'file:///tmp/recording_1.m4a' });
+  it("calls repository.deleteFile with the path (file:// stripped)", async () => {
+    const r = makeRecording({
+      id: "1",
+      filePath: "file:///tmp/recording_1.m4a",
+    });
     const { result, repository } = setup([r]);
     await waitFor(() => expect(result.current.recordings).toHaveLength(1));
 
-    act(() => { result.current.deleteRecording('1'); });
+    act(() => {
+      result.current.deleteRecording("1");
+    });
 
-    expect(repository.deleteFile).toHaveBeenCalledWith('/tmp/recording_1.m4a');
+    expect(repository.deleteFile).toHaveBeenCalledWith("/tmp/recording_1.m4a");
   });
 
-  it('calls repository.save with the updated list', async () => {
-    const r = makeRecording({ id: '1' });
+  it("calls repository.save with the updated list", async () => {
+    const r = makeRecording({ id: "1" });
     const { result, repository } = setup([r]);
     await waitFor(() => expect(result.current.recordings).toHaveLength(1));
 
-    act(() => { result.current.deleteRecording('1'); });
+    act(() => {
+      result.current.deleteRecording("1");
+    });
 
-    const lastSaveCall = repository.save.mock.calls[repository.save.mock.calls.length - 1];
+    const lastSaveCall =
+      repository.save.mock.calls[repository.save.mock.calls.length - 1];
     expect(lastSaveCall[0]).toHaveLength(0);
   });
 
-  it('stops playback if the deleted recording is currently playing', async () => {
-    const r = makeRecording({ id: '1' });
+  it("stops playback if the deleted recording is currently playing", async () => {
+    const r = makeRecording({ id: "1" });
     const { result, onDidStop } = setup([r]);
     await waitFor(() => expect(result.current.recordings).toHaveLength(1));
 
-    await act(async () => { result.current.togglePlay(r); });
-    expect(result.current.playState?.recordingId).toBe('1');
+    await act(async () => {
+      result.current.togglePlay(r);
+    });
+    expect(result.current.playState?.recordingId).toBe("1");
 
-    act(() => { result.current.deleteRecording('1'); });
+    act(() => {
+      result.current.deleteRecording("1");
+    });
 
     expect(result.current.playState).toBeNull();
     expect(onDidStop).toHaveBeenCalled();
   });
 
-  it('is a no-op for a non-existent id', async () => {
-    const r = makeRecording({ id: '1' });
+  it("is a no-op for a non-existent id", async () => {
+    const r = makeRecording({ id: "1" });
     const { result, repository } = setup([r]);
     await waitFor(() => expect(result.current.recordings).toHaveLength(1));
 
-    act(() => { result.current.deleteRecording('nonexistent'); });
+    act(() => {
+      result.current.deleteRecording("nonexistent");
+    });
 
     expect(result.current.recordings).toHaveLength(1);
     expect(repository.deleteFile).not.toHaveBeenCalled();
   });
 });
 
-describe('useRecordings — FIFO cap enforcement', () => {
-  it('trims oldest recordings when adding exceeds maxRecordings', async () => {
-    const r1 = makeRecording({ id: '1' });
-    const r2 = makeRecording({ id: '2', filePath: 'file:///tmp/recording_2.m4a' });
+describe("useRecordings — FIFO cap enforcement", () => {
+  it("trims oldest recordings when adding exceeds maxRecordings", async () => {
+    const r1 = makeRecording({ id: "1" });
+    const r2 = makeRecording({
+      id: "2",
+      filePath: "file:///tmp/recording_2.m4a",
+    });
     const { result } = setup([r1, r2], 2);
     await waitFor(() => expect(result.current.recordings).toHaveLength(2));
 
-    act(() => { result.current.addRecording('/tmp/new.m4a', 1000); });
+    act(() => {
+      result.current.addRecording("/tmp/new.m4a", 1000);
+    });
 
     expect(result.current.recordings).toHaveLength(2);
-    expect(result.current.recordings[0].filePath).toBe('file:///tmp/new.m4a');
-    expect(result.current.recordings[1].id).toBe('1');
+    expect(result.current.recordings[0].filePath).toBe("file:///tmp/new.m4a");
+    expect(result.current.recordings[1].id).toBe("1");
   });
 
-  it('deletes the M4A files for evicted recordings', async () => {
-    const r1 = makeRecording({ id: '1', filePath: 'file:///tmp/r1.m4a' });
-    const r2 = makeRecording({ id: '2', filePath: 'file:///tmp/r2.m4a' });
+  it("deletes the M4A files for evicted recordings", async () => {
+    const r1 = makeRecording({ id: "1", filePath: "file:///tmp/r1.m4a" });
+    const r2 = makeRecording({ id: "2", filePath: "file:///tmp/r2.m4a" });
     const { result, repository } = setup([r1, r2], 2);
     await waitFor(() => expect(result.current.recordings).toHaveLength(2));
 
-    act(() => { result.current.addRecording('/tmp/new.m4a', 1000); });
+    act(() => {
+      result.current.addRecording("/tmp/new.m4a", 1000);
+    });
 
-    expect(repository.deleteFile).toHaveBeenCalledWith('/tmp/r2.m4a');
+    expect(repository.deleteFile).toHaveBeenCalledWith("/tmp/r2.m4a");
   });
 
-  it('does not trim when maxRecordings is 0 (unlimited)', async () => {
-    const r1 = makeRecording({ id: '1' });
+  it("does not trim when maxRecordings is 0 (unlimited)", async () => {
+    const r1 = makeRecording({ id: "1" });
     const { result } = setup([r1], 0);
     await waitFor(() => expect(result.current.recordings).toHaveLength(1));
 
-    act(() => { result.current.addRecording('/tmp/new.m4a', 1000); });
+    act(() => {
+      result.current.addRecording("/tmp/new.m4a", 1000);
+    });
 
     expect(result.current.recordings).toHaveLength(2);
   });
 });
 
-describe('useRecordings — levelHistory', () => {
-  beforeEach(() => { jest.useFakeTimers(); });
-  afterEach(() => { jest.useRealTimers(); });
+describe("useRecordings — levelHistory", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
 
-  it('is exposed in the hook return value', async () => {
+  it("is exposed in the hook return value", async () => {
     const { result } = setup();
     await waitFor(() => expect(result.current.levelHistory).toBeDefined());
     expect(result.current.levelHistory).toHaveLength(LEVEL_HISTORY_SIZE);
-    expect(result.current.levelHistory.every(v => v === 0)).toBe(true);
+    expect(result.current.levelHistory.every((v) => v === 0)).toBe(true);
   });
 
-  it('updates during playback', async () => {
+  it("updates during playback", async () => {
     const recording = makeRecording();
     const repository = new StubRecordingsRepository();
     repository.seed([recording]);
     const decoderService = new StubAudioDecoderService();
-    decoderService.decodeAudioData.mockResolvedValue(makeStubAudioBuffer(44100, 44100, 0.5));
+    decoderService.decodeAudioData.mockResolvedValue(
+      makeStubAudioBuffer(44100, 44100, 0.5),
+    );
     const audioContext = makeStubAudioContext();
     const onWillPlay = jest.fn().mockResolvedValue(undefined);
     const onDidStop = jest.fn().mockResolvedValue(undefined);
 
     const { result } = renderHook(() =>
-      useRecordings({ onWillPlay, onDidStop }, audioContext, repository, decoderService, 0),
+      useRecordings(
+        { onWillPlay, onDidStop },
+        audioContext,
+        repository,
+        decoderService,
+        0,
+      ),
     );
 
     await waitFor(() => expect(result.current.recordings).toHaveLength(1));
 
-    await act(async () => { result.current.togglePlay(recording); });
+    await act(async () => {
+      result.current.togglePlay(recording);
+    });
 
-    act(() => { jest.advanceTimersByTime(93 * 3); });
+    act(() => {
+      jest.advanceTimersByTime(93 * 3);
+    });
 
-    const hasNonZero = result.current.levelHistory.some(v => v > 0);
+    const hasNonZero = result.current.levelHistory.some((v) => v > 0);
     expect(hasNonZero).toBe(true);
   });
 
-  it('resets to zeros when playback stops', async () => {
+  it("resets to zeros when playback stops", async () => {
     const recording = makeRecording();
     const repository = new StubRecordingsRepository();
     repository.seed([recording]);
     const decoderService = new StubAudioDecoderService();
-    decoderService.decodeAudioData.mockResolvedValue(makeStubAudioBuffer(44100, 44100, 0.5));
+    decoderService.decodeAudioData.mockResolvedValue(
+      makeStubAudioBuffer(44100, 44100, 0.5),
+    );
     const audioContext = makeStubAudioContext();
     const onWillPlay = jest.fn().mockResolvedValue(undefined);
     const onDidStop = jest.fn().mockResolvedValue(undefined);
 
     const { result } = renderHook(() =>
-      useRecordings({ onWillPlay, onDidStop }, audioContext, repository, decoderService, 0),
+      useRecordings(
+        { onWillPlay, onDidStop },
+        audioContext,
+        repository,
+        decoderService,
+        0,
+      ),
     );
 
     await waitFor(() => expect(result.current.recordings).toHaveLength(1));
 
-    await act(async () => { result.current.togglePlay(recording); });
-    act(() => { jest.advanceTimersByTime(93 * 3); });
+    await act(async () => {
+      result.current.togglePlay(recording);
+    });
+    act(() => {
+      jest.advanceTimersByTime(93 * 3);
+    });
 
     // Stop playback
-    act(() => { result.current.togglePlay(recording); });
+    act(() => {
+      result.current.togglePlay(recording);
+    });
 
-    expect(result.current.levelHistory.every(v => v === 0)).toBe(true);
+    expect(result.current.levelHistory.every((v) => v === 0)).toBe(true);
   });
 
-  it('resets to zeros when playback ends naturally (onEnded)', async () => {
+  it("resets to zeros when playback ends naturally (onEnded)", async () => {
     const recording = makeRecording();
     const repository = new StubRecordingsRepository();
     repository.seed([recording]);
     const decoderService = new StubAudioDecoderService();
-    decoderService.decodeAudioData.mockResolvedValue(makeStubAudioBuffer(44100, 44100, 0.5));
+    decoderService.decodeAudioData.mockResolvedValue(
+      makeStubAudioBuffer(44100, 44100, 0.5),
+    );
     const audioContext = makeStubAudioContext();
     const stubSource = makeStubBufferSourceNode();
     (audioContext.createBufferSource as jest.Mock).mockReturnValue(stubSource);
@@ -345,17 +467,29 @@ describe('useRecordings — levelHistory', () => {
     const onDidStop = jest.fn().mockResolvedValue(undefined);
 
     const { result } = renderHook(() =>
-      useRecordings({ onWillPlay, onDidStop }, audioContext, repository, decoderService, 0),
+      useRecordings(
+        { onWillPlay, onDidStop },
+        audioContext,
+        repository,
+        decoderService,
+        0,
+      ),
     );
 
     await waitFor(() => expect(result.current.recordings).toHaveLength(1));
 
-    await act(async () => { result.current.togglePlay(recording); });
-    act(() => { jest.advanceTimersByTime(93 * 3); });
+    await act(async () => {
+      result.current.togglePlay(recording);
+    });
+    act(() => {
+      jest.advanceTimersByTime(93 * 3);
+    });
 
     // Simulate natural end
-    act(() => { stubSource.onEnded?.(); });
+    act(() => {
+      stubSource.onEnded?.();
+    });
 
-    expect(result.current.levelHistory.every(v => v === 0)).toBe(true);
+    expect(result.current.levelHistory.every((v) => v === 0)).toBe(true);
   });
 });

--- a/src/hooks/__tests__/useVoiceMirror.test.ts
+++ b/src/hooks/__tests__/useVoiceMirror.test.ts
@@ -1,17 +1,20 @@
-jest.mock('../../lib/sentryHelpers', () => ({
+jest.mock("../../lib/sentryHelpers", () => ({
   captureException: jest.fn(),
   captureMessage: jest.fn(),
   addBreadcrumb: jest.fn(),
 }));
 
-import { renderHook, act, waitFor } from '@testing-library/react-native';
-import { useVoiceMirror } from '../useVoiceMirror';
-import { StubAudioRecordingService } from '../../__tests__/stubs/stubAudioRecordingService';
-import { StubAudioEncoderService } from '../../__tests__/stubs/stubAudioEncoderService';
-import { StubRecordingsRepository } from '../../__tests__/stubs/stubRecordingsRepository';
-import { makeStubAudioContext, makeStubBufferSourceNode } from '../../__tests__/stubs/stubAudioContext';
-import { LEVEL_HISTORY_SIZE } from '../../constants/audio';
-import { DEFAULT_SETTINGS } from '../../types/settings';
+import { renderHook, act, waitFor } from "@testing-library/react-native";
+import { useVoiceMirror } from "../useVoiceMirror";
+import { StubAudioRecordingService } from "../../__tests__/stubs/stubAudioRecordingService";
+import { StubAudioEncoderService } from "../../__tests__/stubs/stubAudioEncoderService";
+import { StubRecordingsRepository } from "../../__tests__/stubs/stubRecordingsRepository";
+import {
+  makeStubAudioContext,
+  makeStubBufferSourceNode,
+} from "../../__tests__/stubs/stubAudioContext";
+import { LEVEL_HISTORY_SIZE } from "../../constants/audio";
+import { DEFAULT_SETTINGS } from "../../types/settings";
 
 const {
   voiceThresholdDb: VOICE_THRESHOLD_DB,
@@ -41,10 +44,25 @@ function setup() {
   const audioContext = makeStubAudioContext();
 
   const { result, unmount } = renderHook(() =>
-    useVoiceMirror(onRecordingComplete, audioContext, recordingService, encoderService, repository, DEFAULT_SETTINGS),
+    useVoiceMirror(
+      onRecordingComplete,
+      audioContext,
+      recordingService,
+      encoderService,
+      repository,
+      DEFAULT_SETTINGS,
+    ),
   );
 
-  return { result, unmount, onRecordingComplete, recordingService, encoderService, repository, audioContext };
+  return {
+    result,
+    unmount,
+    onRecordingComplete,
+    recordingService,
+    encoderService,
+    repository,
+    audioContext,
+  };
 }
 
 async function setupWithPermission() {
@@ -87,33 +105,40 @@ afterEach(() => {
 // Permissions
 // ---------------------------------------------------------------------------
 
-describe('useVoiceMirror — permissions', () => {
-  it('hasPermission is false before the effect runs', () => {
+describe("useVoiceMirror — permissions", () => {
+  it("hasPermission is false before the effect runs", () => {
     const { result } = setup();
     expect(result.current.hasPermission).toBe(false);
   });
 
-  it('hasPermission becomes true after permission is granted', async () => {
+  it("hasPermission becomes true after permission is granted", async () => {
     const { result } = setup();
     await waitFor(() => expect(result.current.hasPermission).toBe(true));
   });
 
-  it('permissionDenied becomes true when permission is Denied', async () => {
+  it("permissionDenied becomes true when permission is Denied", async () => {
     const recordingService = new StubAudioRecordingService();
-    recordingService.requestRecordingPermissions.mockResolvedValue('Denied');
+    recordingService.requestRecordingPermissions.mockResolvedValue("Denied");
     const { result } = renderHook(() =>
-      useVoiceMirror(jest.fn(), makeStubAudioContext(), recordingService, new StubAudioEncoderService(), new StubRecordingsRepository(), DEFAULT_SETTINGS),
+      useVoiceMirror(
+        jest.fn(),
+        makeStubAudioContext(),
+        recordingService,
+        new StubAudioEncoderService(),
+        new StubRecordingsRepository(),
+        DEFAULT_SETTINGS,
+      ),
     );
     await waitFor(() => expect(result.current.permissionDenied).toBe(true));
     expect(result.current.hasPermission).toBe(false);
   });
 
-  it('calls setAudioSessionOptions once after permission is granted', async () => {
+  it("calls setAudioSessionOptions once after permission is granted", async () => {
     const { recordingService } = await setupWithPermission();
     expect(recordingService.setAudioSessionOptions).toHaveBeenCalledTimes(1);
   });
 
-  it('calls createRecorder once after permission is granted', async () => {
+  it("calls createRecorder once after permission is granted", async () => {
     const { recordingService } = await setupWithPermission();
     expect(recordingService.createRecorder).toHaveBeenCalledTimes(1);
   });
@@ -123,8 +148,8 @@ describe('useVoiceMirror — permissions', () => {
 // Phase: idle → recording
 // ---------------------------------------------------------------------------
 
-describe('useVoiceMirror — idle → recording', () => {
-  it('stays idle when audio is below voice threshold', async () => {
+describe("useVoiceMirror — idle → recording", () => {
+  it("stays idle when audio is below voice threshold", async () => {
     const { result, recordingService } = await setupWithPermission();
 
     act(() => {
@@ -134,10 +159,10 @@ describe('useVoiceMirror — idle → recording', () => {
       }
     });
 
-    expect(result.current.phase).toBe('idle');
+    expect(result.current.phase).toBe("idle");
   });
 
-  it('resets voice onset timer when audio drops below threshold mid-onset', async () => {
+  it("resets voice onset timer when audio drops below threshold mid-onset", async () => {
     const { result, recordingService } = await setupWithPermission();
 
     act(() => {
@@ -149,30 +174,34 @@ describe('useVoiceMirror — idle → recording', () => {
       recordingService.recorder.simulateChunk(makeSilentChunk());
     });
 
-    expect(result.current.phase).toBe('idle');
+    expect(result.current.phase).toBe("idle");
   });
 
-  it('transitions to recording after sustained voice above threshold', async () => {
+  it("transitions to recording after sustained voice above threshold", async () => {
     const { result, recordingService } = await setupWithPermission();
 
-    act(() => { simulateVoiceOnset(recordingService); });
+    act(() => {
+      simulateVoiceOnset(recordingService);
+    });
 
-    expect(result.current.phase).toBe('recording');
+    expect(result.current.phase).toBe("recording");
   });
 
-  it('calls encoderService.startEncoding exactly once when recording begins', async () => {
+  it("calls encoderService.startEncoding exactly once when recording begins", async () => {
     const { recordingService, encoderService } = await setupWithPermission();
 
-    act(() => { simulateVoiceOnset(recordingService); });
+    act(() => {
+      simulateVoiceOnset(recordingService);
+    });
 
     expect(encoderService.startEncoding).toHaveBeenCalledTimes(1);
     expect(encoderService.startEncoding).toHaveBeenCalledWith(
-      expect.stringContaining('.m4a'),
+      expect.stringContaining(".m4a"),
       expect.any(Number),
     );
   });
 
-  it('retroactively feeds pre-voice chunks to encodeChunk in beginEncoding', async () => {
+  it("retroactively feeds pre-voice chunks to encodeChunk in beginEncoding", async () => {
     const { recordingService, encoderService } = await setupWithPermission();
 
     act(() => {
@@ -180,7 +209,9 @@ describe('useVoiceMirror — idle → recording', () => {
       recordingService.recorder.simulateChunk(makeLoudChunk());
     });
 
-    act(() => { simulateVoiceOnset(recordingService); });
+    act(() => {
+      simulateVoiceOnset(recordingService);
+    });
 
     expect(encoderService.encodeChunk).toHaveBeenCalled();
   });
@@ -190,8 +221,8 @@ describe('useVoiceMirror — idle → recording', () => {
 // Phase: recording → playing
 // ---------------------------------------------------------------------------
 
-describe('useVoiceMirror — recording → playing', () => {
-  it('transitions to playing after sufficient silence following minimum recording', async () => {
+describe("useVoiceMirror — recording → playing", () => {
+  it("transitions to playing after sufficient silence following minimum recording", async () => {
     const { result, recordingService } = await setupWithPermission();
 
     act(() => {
@@ -204,10 +235,10 @@ describe('useVoiceMirror — recording → playing', () => {
       simulateSilence(recordingService);
     });
 
-    await waitFor(() => expect(result.current.phase).toBe('playing'));
+    await waitFor(() => expect(result.current.phase).toBe("playing"));
   });
 
-  it('does not transition to playing if recording is shorter than MIN_RECORDING_MS', async () => {
+  it("does not transition to playing if recording is shorter than MIN_RECORDING_MS", async () => {
     const { result, recordingService } = await setupWithPermission();
 
     // Use exactly the minimum chunks for onset (4 × 100ms = onset at 300ms elapsed).
@@ -224,11 +255,12 @@ describe('useVoiceMirror — recording → playing', () => {
       recordingService.recorder.simulateChunk(makeSilentChunk(100));
     });
 
-    expect(result.current.phase).toBe('recording');
+    expect(result.current.phase).toBe("recording");
   });
 
-  it('awaits encoderService.stopEncoding when transitioning to playing', async () => {
-    const { result, recordingService, encoderService } = await setupWithPermission();
+  it("awaits encoderService.stopEncoding when transitioning to playing", async () => {
+    const { result, recordingService, encoderService } =
+      await setupWithPermission();
 
     act(() => {
       simulateVoiceOnset(recordingService);
@@ -240,12 +272,13 @@ describe('useVoiceMirror — recording → playing', () => {
       simulateSilence(recordingService);
     });
 
-    await waitFor(() => expect(result.current.phase).toBe('playing'));
+    await waitFor(() => expect(result.current.phase).toBe("playing"));
     expect(encoderService.stopEncoding).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onRecordingComplete with filePath and durationMs when encoding succeeds', async () => {
-    const { result, recordingService, encoderService, onRecordingComplete } = await setupWithPermission();
+  it("calls onRecordingComplete with filePath and durationMs when encoding succeeds", async () => {
+    const { result, recordingService, encoderService, onRecordingComplete } =
+      await setupWithPermission();
     encoderService.stopEncoding.mockResolvedValue(1500);
 
     act(() => {
@@ -258,12 +291,21 @@ describe('useVoiceMirror — recording → playing', () => {
       simulateSilence(recordingService);
     });
 
-    await waitFor(() => expect(result.current.phase).toBe('playing'));
-    expect(onRecordingComplete).toHaveBeenCalledWith(expect.stringContaining('.m4a'), 1500);
+    await waitFor(() => expect(result.current.phase).toBe("playing"));
+    expect(onRecordingComplete).toHaveBeenCalledWith(
+      expect.stringContaining(".m4a"),
+      1500,
+    );
   });
 
-  it('calls repository.deleteFile and does NOT call onRecordingComplete when stopEncoding returns 0', async () => {
-    const { result, recordingService, encoderService, repository, onRecordingComplete } = await setupWithPermission();
+  it("calls repository.deleteFile and does NOT call onRecordingComplete when stopEncoding returns 0", async () => {
+    const {
+      result,
+      recordingService,
+      encoderService,
+      repository,
+      onRecordingComplete,
+    } = await setupWithPermission();
     encoderService.stopEncoding.mockResolvedValue(0);
 
     act(() => {
@@ -276,13 +318,14 @@ describe('useVoiceMirror — recording → playing', () => {
       simulateSilence(recordingService);
     });
 
-    await waitFor(() => expect(result.current.phase).toBe('playing'));
+    await waitFor(() => expect(result.current.phase).toBe("playing"));
     expect(repository.deleteFile).toHaveBeenCalledTimes(1);
     expect(onRecordingComplete).not.toHaveBeenCalled();
   });
 
-  it('sets recordingError when stopEncoding returns 0', async () => {
-    const { result, recordingService, encoderService } = await setupWithPermission();
+  it("sets recordingError when stopEncoding returns 0", async () => {
+    const { result, recordingService, encoderService } =
+      await setupWithPermission();
     encoderService.stopEncoding.mockResolvedValue(0);
 
     act(() => {
@@ -296,7 +339,7 @@ describe('useVoiceMirror — recording → playing', () => {
     });
 
     await waitFor(() => expect(result.current.recordingError).not.toBeNull());
-    expect(result.current.recordingError).toBe('recording_failed');
+    expect(result.current.recordingError).toBe("recording_failed");
   });
 });
 
@@ -304,36 +347,44 @@ describe('useVoiceMirror — recording → playing', () => {
 // Phase: pause / resume
 // ---------------------------------------------------------------------------
 
-describe('useVoiceMirror — pause / resume', () => {
-  it('transitions to paused when togglePause is called in idle', async () => {
+describe("useVoiceMirror — pause / resume", () => {
+  it("transitions to paused when togglePause is called in idle", async () => {
     const { result } = await setupWithPermission();
 
-    await act(async () => { result.current.togglePause(); });
+    await act(async () => {
+      result.current.togglePause();
+    });
 
-    expect(result.current.phase).toBe('paused');
+    expect(result.current.phase).toBe("paused");
   });
 
-  it('calls setAudioSessionActivity(false) when pausing', async () => {
+  it("calls setAudioSessionActivity(false) when pausing", async () => {
     const { result, recordingService } = await setupWithPermission();
 
-    await act(async () => { result.current.togglePause(); });
+    await act(async () => {
+      result.current.togglePause();
+    });
 
     const calls = recordingService.setAudioSessionActivity.mock.calls;
     const pauseCall = calls.find(([arg]) => arg === false);
     expect(pauseCall).toBeDefined();
   });
 
-  it('returns to idle when togglePause is called while paused', async () => {
+  it("returns to idle when togglePause is called while paused", async () => {
     const { result } = await setupWithPermission();
 
-    await act(async () => { result.current.togglePause(); });
-    expect(result.current.phase).toBe('paused');
+    await act(async () => {
+      result.current.togglePause();
+    });
+    expect(result.current.phase).toBe("paused");
 
-    await act(async () => { result.current.togglePause(); });
-    expect(result.current.phase).toBe('idle');
+    await act(async () => {
+      result.current.togglePause();
+    });
+    expect(result.current.phase).toBe("idle");
   });
 
-  it('zeroes out levelHistory when paused', async () => {
+  it("zeroes out levelHistory when paused", async () => {
     const { result, recordingService } = await setupWithPermission();
 
     act(() => {
@@ -343,10 +394,12 @@ describe('useVoiceMirror — pause / resume', () => {
       }
     });
 
-    await act(async () => { result.current.togglePause(); });
+    await act(async () => {
+      result.current.togglePause();
+    });
 
     expect(result.current.levelHistory).toHaveLength(LEVEL_HISTORY_SIZE);
-    expect(result.current.levelHistory.every(v => v === 0)).toBe(true);
+    expect(result.current.levelHistory.every((v) => v === 0)).toBe(true);
   });
 });
 
@@ -354,29 +407,41 @@ describe('useVoiceMirror — pause / resume', () => {
 // Pause during recording cleanup
 // ---------------------------------------------------------------------------
 
-describe('useVoiceMirror — pause during recording cleanup', () => {
-  it('calls stopEncoding and deleteFile when paused during recording', async () => {
-    const { result, recordingService, encoderService, repository } = await setupWithPermission();
+describe("useVoiceMirror — pause during recording cleanup", () => {
+  it("calls stopEncoding and deleteFile when paused during recording", async () => {
+    const { result, recordingService, encoderService, repository } =
+      await setupWithPermission();
 
-    act(() => { simulateVoiceOnset(recordingService); });
-    expect(result.current.phase).toBe('recording');
+    act(() => {
+      simulateVoiceOnset(recordingService);
+    });
+    expect(result.current.phase).toBe("recording");
 
-    await act(async () => { result.current.togglePause(); });
+    await act(async () => {
+      result.current.togglePause();
+    });
 
-    expect(result.current.phase).toBe('paused');
+    expect(result.current.phase).toBe("paused");
     expect(encoderService.stopEncoding).toHaveBeenCalledTimes(1);
     expect(repository.deleteFile).toHaveBeenCalledTimes(1);
-    expect(repository.deleteFile).toHaveBeenCalledWith(expect.stringContaining('.m4a'));
+    expect(repository.deleteFile).toHaveBeenCalledWith(
+      expect.stringContaining(".m4a"),
+    );
   });
 
-  it('skips stopEncoding but still deletes file when encoder had failed', async () => {
-    const { result, recordingService, encoderService, repository } = await setupWithPermission();
+  it("skips stopEncoding but still deletes file when encoder had failed", async () => {
+    const { result, recordingService, encoderService, repository } =
+      await setupWithPermission();
 
-    act(() => { simulateVoiceOnset(recordingService); });
-    expect(result.current.phase).toBe('recording');
+    act(() => {
+      simulateVoiceOnset(recordingService);
+    });
+    expect(result.current.phase).toBe("recording");
 
     // Make encodeChunk fail so encoderFailedRef becomes true
-    encoderService.encodeChunk.mockImplementation(() => { throw new Error('encode failed'); });
+    encoderService.encodeChunk.mockImplementation(() => {
+      throw new Error("encode failed");
+    });
 
     act(() => {
       jest.advanceTimersByTime(100);
@@ -386,21 +451,25 @@ describe('useVoiceMirror — pause during recording cleanup', () => {
     // Reset mock to track only pause-related calls
     encoderService.stopEncoding.mockClear();
 
-    await act(async () => { result.current.togglePause(); });
+    await act(async () => {
+      result.current.togglePause();
+    });
 
-    expect(result.current.phase).toBe('paused');
+    expect(result.current.phase).toBe("paused");
     expect(encoderService.stopEncoding).not.toHaveBeenCalled();
     expect(repository.deleteFile).toHaveBeenCalledTimes(1);
   });
 
-  it('does not call stopEncoding or deleteFile when paused from idle', async () => {
+  it("does not call stopEncoding or deleteFile when paused from idle", async () => {
     const { result, encoderService, repository } = await setupWithPermission();
 
-    expect(result.current.phase).toBe('idle');
+    expect(result.current.phase).toBe("idle");
 
-    await act(async () => { result.current.togglePause(); });
+    await act(async () => {
+      result.current.togglePause();
+    });
 
-    expect(result.current.phase).toBe('paused');
+    expect(result.current.phase).toBe("paused");
     expect(encoderService.stopEncoding).not.toHaveBeenCalled();
     expect(repository.deleteFile).not.toHaveBeenCalled();
   });
@@ -410,38 +479,52 @@ describe('useVoiceMirror — pause during recording cleanup', () => {
 // List playback coordination
 // ---------------------------------------------------------------------------
 
-describe('useVoiceMirror — list playback coordination', () => {
-  it('suspendForListPlayback stops the recorder and sets phase to idle', async () => {
+describe("useVoiceMirror — list playback coordination", () => {
+  it("suspendForListPlayback stops the recorder and sets phase to idle", async () => {
     const { result, recordingService } = await setupWithPermission();
 
-    await act(async () => { await result.current.suspendForListPlayback(); });
+    await act(async () => {
+      await result.current.suspendForListPlayback();
+    });
 
     expect(recordingService.recorder.stop).toHaveBeenCalled();
-    expect(result.current.phase).toBe('idle');
+    expect(result.current.phase).toBe("idle");
   });
 
-  it('resumeFromListPlayback restarts monitoring when not user-paused', async () => {
+  it("resumeFromListPlayback restarts monitoring when not user-paused", async () => {
     const { result, recordingService } = await setupWithPermission();
 
     const startCallsBefore = recordingService.recorder.start.mock.calls.length;
 
-    await act(async () => { await result.current.suspendForListPlayback(); });
-    await act(async () => { await result.current.resumeFromListPlayback(); });
+    await act(async () => {
+      await result.current.suspendForListPlayback();
+    });
+    await act(async () => {
+      await result.current.resumeFromListPlayback();
+    });
 
-    expect(recordingService.recorder.start.mock.calls.length).toBeGreaterThan(startCallsBefore);
-    expect(result.current.phase).toBe('idle');
+    expect(recordingService.recorder.start.mock.calls.length).toBeGreaterThan(
+      startCallsBefore,
+    );
+    expect(result.current.phase).toBe("idle");
   });
 
-  it('resumeFromListPlayback stays paused when user had explicitly paused before list playback', async () => {
+  it("resumeFromListPlayback stays paused when user had explicitly paused before list playback", async () => {
     const { result } = await setupWithPermission();
 
-    await act(async () => { result.current.togglePause(); });
-    expect(result.current.phase).toBe('paused');
+    await act(async () => {
+      result.current.togglePause();
+    });
+    expect(result.current.phase).toBe("paused");
 
-    await act(async () => { await result.current.suspendForListPlayback(); });
-    await act(async () => { await result.current.resumeFromListPlayback(); });
+    await act(async () => {
+      await result.current.suspendForListPlayback();
+    });
+    await act(async () => {
+      await result.current.resumeFromListPlayback();
+    });
 
-    expect(result.current.phase).toBe('paused');
+    expect(result.current.phase).toBe("paused");
   });
 });
 
@@ -449,8 +532,8 @@ describe('useVoiceMirror — list playback coordination', () => {
 // Recording timeout
 // ---------------------------------------------------------------------------
 
-describe('useVoiceMirror — recording timeout', () => {
-  it('transitions to playing when speechMs exceeds maxRecordingMs', async () => {
+describe("useVoiceMirror — recording timeout", () => {
+  it("transitions to playing when speechMs exceeds maxRecordingMs", async () => {
     const onRecordingComplete = jest.fn();
     const recordingService = new StubAudioRecordingService();
     const encoderService = new StubAudioEncoderService();
@@ -459,8 +542,12 @@ describe('useVoiceMirror — recording timeout', () => {
 
     const { result } = renderHook(() =>
       useVoiceMirror(
-        onRecordingComplete, audioContext, recordingService,
-        encoderService, repository, { ...DEFAULT_SETTINGS, maxRecordingMs: 2000 },
+        onRecordingComplete,
+        audioContext,
+        recordingService,
+        encoderService,
+        repository,
+        { ...DEFAULT_SETTINGS, maxRecordingMs: 2000 },
       ),
     );
 
@@ -477,10 +564,10 @@ describe('useVoiceMirror — recording timeout', () => {
       }
     });
 
-    await waitFor(() => expect(result.current.phase).toBe('playing'));
+    await waitFor(() => expect(result.current.phase).toBe("playing"));
   });
 
-  it('does not timeout when maxRecordingMs is 0 (unlimited)', async () => {
+  it("does not timeout when maxRecordingMs is 0 (unlimited)", async () => {
     const onRecordingComplete = jest.fn();
     const recordingService = new StubAudioRecordingService();
     const encoderService = new StubAudioEncoderService();
@@ -489,8 +576,12 @@ describe('useVoiceMirror — recording timeout', () => {
 
     const { result } = renderHook(() =>
       useVoiceMirror(
-        onRecordingComplete, audioContext, recordingService,
-        encoderService, repository, { ...DEFAULT_SETTINGS, maxRecordingMs: 0 },
+        onRecordingComplete,
+        audioContext,
+        recordingService,
+        encoderService,
+        repository,
+        { ...DEFAULT_SETTINGS, maxRecordingMs: 0 },
       ),
     );
 
@@ -507,10 +598,10 @@ describe('useVoiceMirror — recording timeout', () => {
       }
     });
 
-    expect(result.current.phase).toBe('recording');
+    expect(result.current.phase).toBe("recording");
   });
 
-  it('calls onRecordingComplete when timeout triggers with valid encoding', async () => {
+  it("calls onRecordingComplete when timeout triggers with valid encoding", async () => {
     const onRecordingComplete = jest.fn();
     const recordingService = new StubAudioRecordingService();
     const encoderService = new StubAudioEncoderService();
@@ -520,8 +611,12 @@ describe('useVoiceMirror — recording timeout', () => {
 
     const { result } = renderHook(() =>
       useVoiceMirror(
-        onRecordingComplete, audioContext, recordingService,
-        encoderService, repository, { ...DEFAULT_SETTINGS, maxRecordingMs: 2000 },
+        onRecordingComplete,
+        audioContext,
+        recordingService,
+        encoderService,
+        repository,
+        { ...DEFAULT_SETTINGS, maxRecordingMs: 2000 },
       ),
     );
 
@@ -538,9 +633,9 @@ describe('useVoiceMirror — recording timeout', () => {
       }
     });
 
-    await waitFor(() => expect(result.current.phase).toBe('playing'));
+    await waitFor(() => expect(result.current.phase).toBe("playing"));
     expect(onRecordingComplete).toHaveBeenCalledWith(
-      expect.stringContaining('.m4a'),
+      expect.stringContaining(".m4a"),
       2000,
     );
   });
@@ -550,8 +645,8 @@ describe('useVoiceMirror — recording timeout', () => {
 // Pre-roll
 // ---------------------------------------------------------------------------
 
-describe('useVoiceMirror — pre-roll', () => {
-  it('includes pre-roll audio before voice detection point in encoding', async () => {
+describe("useVoiceMirror — pre-roll", () => {
+  it("includes pre-roll audio before voice detection point in encoding", async () => {
     const { recordingService, encoderService } = await setupWithPermission();
 
     act(() => {
@@ -561,7 +656,9 @@ describe('useVoiceMirror — pre-roll', () => {
       }
     });
 
-    act(() => { simulateVoiceOnset(recordingService); });
+    act(() => {
+      simulateVoiceOnset(recordingService);
+    });
 
     const totalEncodedFrames = encoderService.encodeChunk.mock.calls.reduce(
       (sum: number, [chunk]: [Float32Array]) => sum + chunk.length,
@@ -572,10 +669,12 @@ describe('useVoiceMirror — pre-roll', () => {
     expect(totalEncodedFrames).toBeGreaterThan(voiceOnsetFrames);
   });
 
-  it('clamps pre-roll to buffer start when less than 100ms of audio exists', async () => {
+  it("clamps pre-roll to buffer start when less than 100ms of audio exists", async () => {
     const { recordingService, encoderService } = await setupWithPermission();
 
-    act(() => { simulateVoiceOnset(recordingService); });
+    act(() => {
+      simulateVoiceOnset(recordingService);
+    });
 
     expect(encoderService.startEncoding).toHaveBeenCalledTimes(1);
     expect(encoderService.encodeChunk).toHaveBeenCalled();
@@ -586,8 +685,8 @@ describe('useVoiceMirror — pre-roll', () => {
 // currentDb state
 // ---------------------------------------------------------------------------
 
-describe('useVoiceMirror — currentDb', () => {
-  it('updates currentDb on audio chunk during idle phase', async () => {
+describe("useVoiceMirror — currentDb", () => {
+  it("updates currentDb on audio chunk during idle phase", async () => {
     const { result, recordingService } = await setupWithPermission();
 
     act(() => {
@@ -596,14 +695,16 @@ describe('useVoiceMirror — currentDb', () => {
     });
 
     expect(result.current.currentDb).not.toBeNull();
-    expect(typeof result.current.currentDb).toBe('number');
+    expect(typeof result.current.currentDb).toBe("number");
   });
 
-  it('updates currentDb on audio chunk during recording phase', async () => {
+  it("updates currentDb on audio chunk during recording phase", async () => {
     const { result, recordingService } = await setupWithPermission();
 
-    act(() => { simulateVoiceOnset(recordingService); });
-    expect(result.current.phase).toBe('recording');
+    act(() => {
+      simulateVoiceOnset(recordingService);
+    });
+    expect(result.current.phase).toBe("recording");
 
     act(() => {
       jest.advanceTimersByTime(100);
@@ -613,7 +714,7 @@ describe('useVoiceMirror — currentDb', () => {
     expect(result.current.currentDb).not.toBeNull();
   });
 
-  it('resets currentDb to null when pausing', async () => {
+  it("resets currentDb to null when pausing", async () => {
     const { result, recordingService } = await setupWithPermission();
 
     act(() => {
@@ -622,11 +723,13 @@ describe('useVoiceMirror — currentDb', () => {
     });
     expect(result.current.currentDb).not.toBeNull();
 
-    await act(async () => { result.current.togglePause(); });
+    await act(async () => {
+      result.current.togglePause();
+    });
     expect(result.current.currentDb).toBeNull();
   });
 
-  it('resets currentDb to null when transitioning to playback', async () => {
+  it("resets currentDb to null when transitioning to playback", async () => {
     const { result, recordingService } = await setupWithPermission();
 
     act(() => {
@@ -639,7 +742,7 @@ describe('useVoiceMirror — currentDb', () => {
       simulateSilence(recordingService);
     });
 
-    await waitFor(() => expect(result.current.phase).toBe('playing'));
+    await waitFor(() => expect(result.current.phase).toBe("playing"));
     expect(result.current.currentDb).toBeNull();
   });
 });
@@ -648,9 +751,10 @@ describe('useVoiceMirror — currentDb', () => {
 // Level history during playback
 // ---------------------------------------------------------------------------
 
-describe('useVoiceMirror — level history during playback', () => {
-  it('levelHistory updates during the playing phase', async () => {
-    const { result, recordingService, audioContext } = await setupWithPermission();
+describe("useVoiceMirror — level history during playback", () => {
+  it("levelHistory updates during the playing phase", async () => {
+    const { result, recordingService, audioContext } =
+      await setupWithPermission();
 
     // Make createBuffer return a buffer with loud audio data
     const loudData = new Float32Array(44100).fill(0.5);
@@ -678,17 +782,20 @@ describe('useVoiceMirror — level history during playback', () => {
       simulateSilence(recordingService);
     });
 
-    await waitFor(() => expect(result.current.phase).toBe('playing'));
+    await waitFor(() => expect(result.current.phase).toBe("playing"));
 
     // Advance timers to trigger playback level ticks
-    act(() => { jest.advanceTimersByTime(93 * 3); });
+    act(() => {
+      jest.advanceTimersByTime(93 * 3);
+    });
 
-    const hasNonZero = result.current.levelHistory.some(v => v > 0);
+    const hasNonZero = result.current.levelHistory.some((v) => v > 0);
     expect(hasNonZero).toBe(true);
   });
 
-  it('levelHistory stops updating after playback ends', async () => {
-    const { result, recordingService, audioContext } = await setupWithPermission();
+  it("levelHistory stops updating after playback ends", async () => {
+    const { result, recordingService, audioContext } =
+      await setupWithPermission();
 
     const loudData = new Float32Array(44100).fill(0.5);
     const stubBuffer = {
@@ -715,15 +822,19 @@ describe('useVoiceMirror — level history during playback', () => {
       simulateSilence(recordingService);
     });
 
-    await waitFor(() => expect(result.current.phase).toBe('playing'));
+    await waitFor(() => expect(result.current.phase).toBe("playing"));
 
     // Trigger onEnded to simulate playback ending
-    act(() => { stubSource.onEnded?.(); });
+    act(() => {
+      stubSource.onEnded?.();
+    });
 
     // Advance timers - should not produce further playback level updates
-    act(() => { jest.advanceTimersByTime(93 * 5); });
+    act(() => {
+      jest.advanceTimersByTime(93 * 5);
+    });
 
     // Phase should be idle now (startMonitoring resets)
-    await waitFor(() => expect(result.current.phase).toBe('idle'));
+    await waitFor(() => expect(result.current.phase).toBe("idle"));
   });
 });

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -1,4 +1,4 @@
-export type Phase = 'idle' | 'recording' | 'playing' | 'paused';
+export type Phase = "idle" | "recording" | "playing" | "paused";
 
 export type VoiceMirrorState = {
   phase: Phase;
@@ -12,4 +12,7 @@ export type VoiceMirrorState = {
   resumeFromListPlayback: () => Promise<void>;
 };
 
-export type RecordingCompleteCallback = (filePath: string, durationMs: number) => void;
+export type RecordingCompleteCallback = (
+  filePath: string,
+  durationMs: number,
+) => void;

--- a/src/hooks/usePlaybackLevelHistory.ts
+++ b/src/hooks/usePlaybackLevelHistory.ts
@@ -1,7 +1,7 @@
-import { useRef, useCallback } from 'react';
-import type { AudioBuffer } from 'react-native-audio-api';
-import { LEVEL_HISTORY_SIZE } from '../constants/audio';
-import { computeNormalizedLevel } from '../lib/audio';
+import { useRef, useCallback } from "react";
+import type { AudioBuffer } from "react-native-audio-api";
+import { LEVEL_HISTORY_SIZE } from "../constants/audio";
+import { computeNormalizedLevel } from "../lib/audio";
 
 const PLAYBACK_TICK_MS = 93;
 const FRAMES_PER_TICK = 4096;
@@ -19,7 +19,11 @@ export function usePlaybackLevelHistory() {
   }, []);
 
   const startPlaybackLevels = useCallback(
-    (audioBuffer: AudioBuffer, startOffsetSec: number, setLevelHistory: LevelHistorySetter) => {
+    (
+      audioBuffer: AudioBuffer,
+      startOffsetSec: number,
+      setLevelHistory: LevelHistorySetter,
+    ) => {
       stopPlaybackLevels();
 
       const channelData = audioBuffer.getChannelData(0);
@@ -32,16 +36,24 @@ export function usePlaybackLevelHistory() {
 
       timerRef.current = setInterval(() => {
         const elapsedMs = Date.now() - playbackStartTime;
-        const currentFrame = startFrame + Math.floor((elapsedMs / 1000) * sampleRate);
+        const currentFrame =
+          startFrame + Math.floor((elapsedMs / 1000) * sampleRate);
 
         if (currentFrame >= totalFrames) {
           stopPlaybackLevels();
           return;
         }
 
-        const framesToRead = Math.min(FRAMES_PER_TICK, totalFrames - currentFrame);
-        const normalized = computeNormalizedLevel(channelData, currentFrame, framesToRead);
-        setLevelHistory(prev => [...prev.slice(1), normalized]);
+        const framesToRead = Math.min(
+          FRAMES_PER_TICK,
+          totalFrames - currentFrame,
+        );
+        const normalized = computeNormalizedLevel(
+          channelData,
+          currentFrame,
+          framesToRead,
+        );
+        setLevelHistory((prev) => [...prev.slice(1), normalized]);
       }, PLAYBACK_TICK_MS);
     },
     [stopPlaybackLevels],

--- a/src/hooks/useRecordings.ts
+++ b/src/hooks/useRecordings.ts
@@ -1,11 +1,14 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
-import type { AudioContext, AudioBufferSourceNode } from 'react-native-audio-api';
-import { LEVEL_HISTORY_SIZE } from '../constants/audio';
-import { usePlaybackLevelHistory } from './usePlaybackLevelHistory';
-import type { Recording } from '../lib/recordings';
-import type { IRecordingsRepository } from '../repositories/RecordingsRepository';
-import type { IAudioDecoderService } from '../services/AudioDecoderService';
-import { captureException, addBreadcrumb } from '../lib/sentryHelpers';
+import { useState, useEffect, useRef, useCallback } from "react";
+import type {
+  AudioContext,
+  AudioBufferSourceNode,
+} from "react-native-audio-api";
+import { LEVEL_HISTORY_SIZE } from "../constants/audio";
+import { usePlaybackLevelHistory } from "./usePlaybackLevelHistory";
+import type { Recording } from "../lib/recordings";
+import type { IRecordingsRepository } from "../repositories/RecordingsRepository";
+import type { IAudioDecoderService } from "../services/AudioDecoderService";
+import { captureException, addBreadcrumb } from "../lib/sentryHelpers";
 
 export type PlayState = { recordingId: string; isPlaying: boolean } | null;
 
@@ -32,8 +35,8 @@ export function useRecordings(
 ): RecordingsState {
   const [recordings, setRecordings] = useState<Recording[]>([]);
   const [playState, setPlayState] = useState<PlayState>(null);
-  const [levelHistory, setLevelHistory] = useState<number[]>(
-    () => new Array(LEVEL_HISTORY_SIZE).fill(0),
+  const [levelHistory, setLevelHistory] = useState<number[]>(() =>
+    new Array(LEVEL_HISTORY_SIZE).fill(0),
   );
   const { startPlaybackLevels, stopPlaybackLevels } = usePlaybackLevelHistory();
   const recordingsRef = useRef<Recording[]>(recordings);
@@ -57,22 +60,25 @@ export function useRecordings(
     };
   }, [repository, stopPlaybackLevels]);
 
-  const stopCurrentPlayer = useCallback((notify: boolean) => {
-    if (sourceRef.current) {
-      sourceRef.current.onEnded = null;
-      sourceRef.current.stop();
-      sourceRef.current = null;
-      setPlayState(null);
-      stopPlaybackLevels();
-      setLevelHistory(new Array(LEVEL_HISTORY_SIZE).fill(0));
-    }
-    if (notify) void options.onDidStop();
-  }, [options, stopPlaybackLevels]);
+  const stopCurrentPlayer = useCallback(
+    (notify: boolean) => {
+      if (sourceRef.current) {
+        sourceRef.current.onEnded = null;
+        sourceRef.current.stop();
+        sourceRef.current = null;
+        setPlayState(null);
+        stopPlaybackLevels();
+        setLevelHistory(new Array(LEVEL_HISTORY_SIZE).fill(0));
+      }
+      if (notify) void options.onDidStop();
+    },
+    [options, stopPlaybackLevels],
+  );
 
   const addRecording = useCallback((filePath: string, durationMs: number) => {
     const entry: Recording = {
       id: String(Date.now()),
-      filePath: 'file://' + filePath,
+      filePath: "file://" + filePath,
       recordedAt: new Date().toISOString(),
       durationMs,
     };
@@ -82,7 +88,7 @@ export function useRecordings(
     if (cap > 0 && next.length > cap) {
       const excess = next.slice(cap);
       for (const r of excess) {
-        repositoryRef.current.deleteFile(r.filePath.replace('file://', ''));
+        repositoryRef.current.deleteFile(r.filePath.replace("file://", ""));
       }
       next = next.slice(0, cap);
     }
@@ -91,77 +97,101 @@ export function useRecordings(
     repositoryRef.current.save(next);
   }, []);
 
-  const deleteRecording = useCallback((id: string) => {
-    const recording = recordingsRef.current.find(r => r.id === id);
-    if (!recording) return;
+  const deleteRecording = useCallback(
+    (id: string) => {
+      const recording = recordingsRef.current.find((r) => r.id === id);
+      if (!recording) return;
 
-    if (playState?.recordingId === id) {
-      stopCurrentPlayer(true);
-    }
+      if (playState?.recordingId === id) {
+        stopCurrentPlayer(true);
+      }
 
-    repository.deleteFile(recording.filePath.replace('file://', ''));
+      repository.deleteFile(recording.filePath.replace("file://", ""));
 
-    const next = recordingsRef.current.filter(r => r.id !== id);
-    setRecordings(next);
-    repositoryRef.current.save(next);
-  }, [playState, repository, stopCurrentPlayer]);
+      const next = recordingsRef.current.filter((r) => r.id !== id);
+      setRecordings(next);
+      repositoryRef.current.save(next);
+    },
+    [playState, repository, stopCurrentPlayer],
+  );
 
-  const togglePlay = useCallback(async (recording: Recording) => {
-    if (!audioContext) return;
+  const togglePlay = useCallback(
+    async (recording: Recording) => {
+      if (!audioContext) return;
 
-    if (playState?.recordingId === recording.id && playState.isPlaying) {
-      stopCurrentPlayer(true);
-      return;
-    }
+      if (playState?.recordingId === recording.id && playState.isPlaying) {
+        stopCurrentPlayer(true);
+        return;
+      }
 
-    if (isDecodingRef.current) return;
+      if (isDecodingRef.current) return;
 
-    const wasAlreadyPlaying = sourceRef.current !== null;
-    stopCurrentPlayer(false);
+      const wasAlreadyPlaying = sourceRef.current !== null;
+      stopCurrentPlayer(false);
 
-    if (!wasAlreadyPlaying) {
-      await options.onWillPlay();
-    }
+      if (!wasAlreadyPlaying) {
+        await options.onWillPlay();
+      }
 
-    setPlayState({ recordingId: recording.id, isPlaying: true });
+      setPlayState({ recordingId: recording.id, isPlaying: true });
 
-    isDecodingRef.current = true;
-    let audioBuffer;
-    try {
-      audioBuffer = await decoderService.decodeAudioData(recording.filePath, audioContext.sampleRate);
-    } catch (e) {
-      console.error('[useRecordings] decodeAudioData failed:', e);
-      captureException(e, {
-        operation: 'AudioDecoder.decodeAudioData',
-        filePath: recording.filePath,
-        recordingId: recording.id,
-        sampleRate: audioContext.sampleRate,
-      });
+      isDecodingRef.current = true;
+      let audioBuffer;
+      try {
+        audioBuffer = await decoderService.decodeAudioData(
+          recording.filePath,
+          audioContext.sampleRate,
+        );
+      } catch (e) {
+        console.error("[useRecordings] decodeAudioData failed:", e);
+        captureException(e, {
+          operation: "AudioDecoder.decodeAudioData",
+          filePath: recording.filePath,
+          recordingId: recording.id,
+          sampleRate: audioContext.sampleRate,
+        });
+        isDecodingRef.current = false;
+        setPlayState(null);
+        await options.onDidStop();
+        return;
+      }
       isDecodingRef.current = false;
-      setPlayState(null);
-      await options.onDidStop();
-      return;
-    }
-    isDecodingRef.current = false;
 
-    const source = audioContext.createBufferSource();
-    sourceRef.current = source;
-    source.buffer = audioBuffer;
-    source.connect(audioContext.destination);
-    source.onEnded = () => {
-      sourceRef.current = null;
-      setPlayState(null);
-      stopPlaybackLevels();
-      setLevelHistory(new Array(LEVEL_HISTORY_SIZE).fill(0));
-      void options.onDidStop();
-    };
-    source.start(0);
-    addBreadcrumb('recordings', 'List playback started', {
-      recordingId: recording.id,
-      durationMs: recording.durationMs,
-    });
-    startPlaybackLevels(audioBuffer, 0, setLevelHistory);
-  }, [playState, audioContext, decoderService, stopCurrentPlayer, options, startPlaybackLevels, stopPlaybackLevels]);
+      const source = audioContext.createBufferSource();
+      sourceRef.current = source;
+      source.buffer = audioBuffer;
+      source.connect(audioContext.destination);
+      source.onEnded = () => {
+        sourceRef.current = null;
+        setPlayState(null);
+        stopPlaybackLevels();
+        setLevelHistory(new Array(LEVEL_HISTORY_SIZE).fill(0));
+        void options.onDidStop();
+      };
+      source.start(0);
+      addBreadcrumb("recordings", "List playback started", {
+        recordingId: recording.id,
+        durationMs: recording.durationMs,
+      });
+      startPlaybackLevels(audioBuffer, 0, setLevelHistory);
+    },
+    [
+      playState,
+      audioContext,
+      decoderService,
+      stopCurrentPlayer,
+      options,
+      startPlaybackLevels,
+      stopPlaybackLevels,
+    ],
+  );
 
-  return { recordings, playState, levelHistory, addRecording, deleteRecording, togglePlay };
+  return {
+    recordings,
+    playState,
+    levelHistory,
+    addRecording,
+    deleteRecording,
+    togglePlay,
+  };
 }

--- a/src/hooks/useVoiceMirror.ts
+++ b/src/hooks/useVoiceMirror.ts
@@ -1,14 +1,25 @@
-import { useEffect, useRef, useState } from 'react';
-import type { AudioContext } from 'react-native-audio-api';
-import { LEVEL_HISTORY_SIZE } from '../constants/audio';
-import { computeLevel } from '../lib/audio';
-import { usePlaybackLevelHistory } from './usePlaybackLevelHistory';
-import type { Phase, VoiceMirrorState, RecordingCompleteCallback } from './types';
-import type { IAudioRecordingService, IAudioRecorder } from '../services/AudioRecordingService';
-import type { IAudioEncoderService } from '../services/AudioEncoderService';
-import type { IRecordingsRepository } from '../repositories/RecordingsRepository';
-import type { DetectionSettings } from '../types/settings';
-import { captureException, captureMessage, addBreadcrumb } from '../lib/sentryHelpers';
+import { useEffect, useRef, useState } from "react";
+import type { AudioContext } from "react-native-audio-api";
+import { LEVEL_HISTORY_SIZE } from "../constants/audio";
+import { computeLevel } from "../lib/audio";
+import { usePlaybackLevelHistory } from "./usePlaybackLevelHistory";
+import type {
+  Phase,
+  VoiceMirrorState,
+  RecordingCompleteCallback,
+} from "./types";
+import type {
+  IAudioRecordingService,
+  IAudioRecorder,
+} from "../services/AudioRecordingService";
+import type { IAudioEncoderService } from "../services/AudioEncoderService";
+import type { IRecordingsRepository } from "../repositories/RecordingsRepository";
+import type { DetectionSettings } from "../types/settings";
+import {
+  captureException,
+  captureMessage,
+  addBreadcrumb,
+} from "../lib/sentryHelpers";
 
 const BUFFER_LENGTH = 4096;
 const CHANNEL_COUNT = 1;
@@ -23,12 +34,12 @@ export function useVoiceMirror(
   repository: IRecordingsRepository,
   settings: DetectionSettings,
 ): VoiceMirrorState {
-  const [phase, setPhase] = useState<Phase>('idle');
+  const [phase, setPhase] = useState<Phase>("idle");
   const [hasPermission, setHasPermission] = useState(false);
   const [permissionDenied, setPermissionDenied] = useState(false);
   const [recordingError, setRecordingError] = useState<string | null>(null);
-  const [levelHistory, setLevelHistory] = useState<number[]>(
-    () => new Array(LEVEL_HISTORY_SIZE).fill(0),
+  const [levelHistory, setLevelHistory] = useState<number[]>(() =>
+    new Array(LEVEL_HISTORY_SIZE).fill(0),
   );
   const [currentDb, setCurrentDb] = useState<number | null>(null);
 
@@ -36,9 +47,11 @@ export function useVoiceMirror(
 
   const audioContextRef = useRef(audioContext);
   const audioRecorderRef = useRef<IAudioRecorder | null>(null);
-  const playerNodeRef = useRef<ReturnType<NonNullable<typeof audioContext>['createBufferSource']> | null>(null);
+  const playerNodeRef = useRef<ReturnType<
+    NonNullable<typeof audioContext>["createBufferSource"]
+  > | null>(null);
 
-  const phaseRef = useRef<Phase>('idle');
+  const phaseRef = useRef<Phase>("idle");
   const voiceStartTimeRef = useRef<number | null>(null);
   const silenceStartTimeRef = useRef<number | null>(null);
 
@@ -60,16 +73,21 @@ export function useVoiceMirror(
 
     (async () => {
       const status = await recordingService.requestRecordingPermissions();
-      if (status !== 'Granted') {
+      if (status !== "Granted") {
         setPermissionDenied(true);
-        addBreadcrumb('voicemirror', 'Microphone permission denied', undefined, 'warning');
+        addBreadcrumb(
+          "voicemirror",
+          "Microphone permission denied",
+          undefined,
+          "warning",
+        );
         return;
       }
       setHasPermission(true);
-      addBreadcrumb('voicemirror', 'Microphone permission granted');
+      addBreadcrumb("voicemirror", "Microphone permission granted");
       recordingService.setAudioSessionOptions({
-        iosCategory: 'playAndRecord',
-        iosOptions: ['defaultToSpeaker'],
+        iosCategory: "playAndRecord",
+        iosOptions: ["defaultToSpeaker"],
       });
       audioRecorderRef.current = recordingService.createRecorder();
       await startMonitoringRef.current();
@@ -91,9 +109,9 @@ export function useVoiceMirror(
       encoderService.startEncoding(filePath, context.sampleRate);
       pendingFilePathRef.current = filePath;
     } catch (e) {
-      console.error('[AudioEncoder] startEncoding failed:', e);
+      console.error("[AudioEncoder] startEncoding failed:", e);
       captureException(e, {
-        operation: 'AudioEncoder.startEncoding',
+        operation: "AudioEncoder.startEncoding",
         filePath,
         sampleRate: context.sampleRate,
       });
@@ -114,10 +132,10 @@ export function useVoiceMirror(
       try {
         encoderService.encodeChunk(slice);
       } catch (e) {
-        console.error('[AudioEncoder] encodeChunk failed:', e);
+        console.error("[AudioEncoder] encodeChunk failed:", e);
         captureException(e, {
-          operation: 'AudioEncoder.encodeChunk',
-          phase: 'catchup',
+          operation: "AudioEncoder.encodeChunk",
+          phase: "catchup",
           filePath,
         });
         encoderFailedRef.current = true;
@@ -125,25 +143,30 @@ export function useVoiceMirror(
     }
   }
 
-  function tickStateMachine(db: number, totalFrames: number, sampleRate: number) {
+  function tickStateMachine(
+    db: number,
+    totalFrames: number,
+    sampleRate: number,
+  ) {
     const now = Date.now();
     const s = settingsRef.current;
 
-    if (phaseRef.current === 'idle') {
+    if (phaseRef.current === "idle") {
       if (db > s.voiceThresholdDb) {
         if (voiceStartTimeRef.current === null) {
           voiceStartTimeRef.current = now;
           const preRollFrames = Math.round((PRE_ROLL_MS / 1000) * sampleRate);
-          const bufferStartFrame = totalFramesRef.current - bufferedFramesRef.current;
+          const bufferStartFrame =
+            totalFramesRef.current - bufferedFramesRef.current;
           voiceStartFrameRef.current = Math.max(
             bufferStartFrame,
             totalFrames - preRollFrames,
           );
         } else if (now - voiceStartTimeRef.current >= s.voiceOnsetMs) {
           silenceStartTimeRef.current = null;
-          phaseRef.current = 'recording';
-          setPhase('recording');
-          addBreadcrumb('voicemirror', 'Recording started', {
+          phaseRef.current = "recording";
+          setPhase("recording");
+          addBreadcrumb("voicemirror", "Recording started", {
             voiceStartFrame: voiceStartFrameRef.current,
           });
           beginEncoding();
@@ -151,14 +174,15 @@ export function useVoiceMirror(
       } else {
         voiceStartTimeRef.current = null;
       }
-    } else if (phaseRef.current === 'recording') {
-      const speechMs = ((totalFrames - voiceStartFrameRef.current) / sampleRate) * 1000;
+    } else if (phaseRef.current === "recording") {
+      const speechMs =
+        ((totalFrames - voiceStartFrameRef.current) / sampleRate) * 1000;
 
       if (s.maxRecordingMs > 0 && speechMs >= s.maxRecordingMs) {
         silenceStartTimeRef.current = null;
-        phaseRef.current = 'playing';
-        setPhase('playing');
-        addBreadcrumb('voicemirror', 'Recording stopped, playing back');
+        phaseRef.current = "playing";
+        setPhase("playing");
+        addBreadcrumb("voicemirror", "Recording stopped, playing back");
         void stopAndPlay();
         return;
       }
@@ -168,9 +192,9 @@ export function useVoiceMirror(
           silenceStartTimeRef.current = now;
         } else if (now - silenceStartTimeRef.current >= s.silenceDurationMs) {
           silenceStartTimeRef.current = null;
-          phaseRef.current = 'playing';
-          setPhase('playing');
-          addBreadcrumb('voicemirror', 'Recording stopped, playing back');
+          phaseRef.current = "playing";
+          setPhase("playing");
+          addBreadcrumb("voicemirror", "Recording stopped, playing back");
           void stopAndPlay();
         }
       } else if (db >= s.silenceThresholdDb) {
@@ -189,7 +213,7 @@ export function useVoiceMirror(
     voiceStartTimeRef.current = null;
     silenceStartTimeRef.current = null;
     voiceStartFrameRef.current = 0;
-    phaseRef.current = 'idle';
+    phaseRef.current = "idle";
     pendingFilePathRef.current = null;
     encoderFailedRef.current = false;
     setRecordingError(null);
@@ -197,18 +221,22 @@ export function useVoiceMirror(
     await recordingService.setAudioSessionActivity(true);
     await context.resume();
     recorder.start();
-    addBreadcrumb('voicemirror', 'Monitoring started', {
+    addBreadcrumb("voicemirror", "Monitoring started", {
       sampleRate: context.sampleRate,
     });
 
     recorder.onAudioReady(
-      { sampleRate: context.sampleRate, bufferLength: BUFFER_LENGTH, channelCount: CHANNEL_COUNT },
+      {
+        sampleRate: context.sampleRate,
+        bufferLength: BUFFER_LENGTH,
+        channelCount: CHANNEL_COUNT,
+      },
       ({ chunk, numFrames }) => {
         chunksRef.current.push(chunk);
         totalFramesRef.current += numFrames;
         bufferedFramesRef.current += numFrames;
 
-        if (phaseRef.current === 'idle' && voiceStartTimeRef.current === null) {
+        if (phaseRef.current === "idle" && voiceStartTimeRef.current === null) {
           const maxFrames = MAX_IDLE_BUFFER_SECS * context.sampleRate;
           while (
             chunksRef.current.length > 1 &&
@@ -219,27 +247,31 @@ export function useVoiceMirror(
           }
         }
 
-        if (phaseRef.current === 'recording' && pendingFilePathRef.current && !encoderFailedRef.current) {
+        if (
+          phaseRef.current === "recording" &&
+          pendingFilePathRef.current &&
+          !encoderFailedRef.current
+        ) {
           try {
             encoderService.encodeChunk(chunk);
           } catch (e) {
-            console.error('[AudioEncoder] encodeChunk failed:', e);
+            console.error("[AudioEncoder] encodeChunk failed:", e);
             captureException(e, {
-              operation: 'AudioEncoder.encodeChunk',
-              phase: 'streaming',
+              operation: "AudioEncoder.encodeChunk",
+              phase: "streaming",
             });
             encoderFailedRef.current = true;
           }
         }
 
         const { normalized, db } = computeLevel(chunk, 0, numFrames);
-        setLevelHistory(prev => [...prev.slice(1), normalized]);
+        setLevelHistory((prev) => [...prev.slice(1), normalized]);
         setCurrentDb(db);
         tickStateMachine(db, totalFramesRef.current, context.sampleRate);
       },
     );
 
-    setPhase('idle');
+    setPhase("idle");
   }
 
   startMonitoringRef.current = startMonitoring;
@@ -265,12 +297,16 @@ export function useVoiceMirror(
       try {
         durationMs = await Promise.race([
           encoderService.stopEncoding(),
-          new Promise<number>((_, reject) => setTimeout(() => reject(new Error('stopEncoding timed out')), 5000)),
+          new Promise<number>((_, reject) =>
+            setTimeout(() => reject(new Error("stopEncoding timed out")), 5000),
+          ),
         ]);
         if (durationMs === 0) {
-          console.error(`[AudioEncoder] stopEncoding returned 0 for ${filePath}`);
-          captureMessage('AudioEncoder stopEncoding returned duration 0', {
-            operation: 'AudioEncoder.stopEncoding',
+          console.error(
+            `[AudioEncoder] stopEncoding returned 0 for ${filePath}`,
+          );
+          captureMessage("AudioEncoder stopEncoding returned duration 0", {
+            operation: "AudioEncoder.stopEncoding",
             filePath,
             sampleRate: context.sampleRate,
           });
@@ -278,23 +314,29 @@ export function useVoiceMirror(
       } catch (e) {
         console.error(`[AudioEncoder] stopEncoding threw for ${filePath}:`, e);
         captureException(e, {
-          operation: 'AudioEncoder.stopEncoding',
+          operation: "AudioEncoder.stopEncoding",
           filePath,
           sampleRate: context.sampleRate,
         });
       }
     } else if (filePath && encoderFailedRef.current) {
-      console.error(`[AudioEncoder] skipped stopEncoding due to prior chunk error: ${filePath}`);
-      captureMessage('AudioEncoder skipped stopEncoding due to prior chunk error', {
-        operation: 'AudioEncoder.stopEncoding',
-        filePath,
-        reason: 'prior_chunk_error',
-      }, 'warning');
+      console.error(
+        `[AudioEncoder] skipped stopEncoding due to prior chunk error: ${filePath}`,
+      );
+      captureMessage(
+        "AudioEncoder skipped stopEncoding due to prior chunk error",
+        {
+          operation: "AudioEncoder.stopEncoding",
+          filePath,
+          reason: "prior_chunk_error",
+        },
+        "warning",
+      );
     }
 
     if (filePath && durationMs === 0) {
       repository.deleteFile(filePath);
-      setRecordingError('recording_failed');
+      setRecordingError("recording_failed");
     }
 
     if (filePath && durationMs > 0) {
@@ -302,7 +344,11 @@ export function useVoiceMirror(
     }
 
     const bufferedFrames = bufferedFramesRef.current;
-    const audioBuffer = context.createBuffer(1, bufferedFrames, context.sampleRate);
+    const audioBuffer = context.createBuffer(
+      1,
+      bufferedFrames,
+      context.sampleRate,
+    );
     let offset = 0;
     for (const chunk of chunksRef.current) {
       audioBuffer.copyToChannel(chunk, 0, offset);
@@ -310,7 +356,8 @@ export function useVoiceMirror(
     }
 
     const bufferStartFrame = totalFramesRef.current - bufferedFramesRef.current;
-    const voiceStartSecs = (voiceStartFrameRef.current - bufferStartFrame) / context.sampleRate;
+    const voiceStartSecs =
+      (voiceStartFrameRef.current - bufferStartFrame) / context.sampleRate;
 
     const playerNode = context.createBufferSource();
     playerNodeRef.current = playerNode;
@@ -335,7 +382,7 @@ export function useVoiceMirror(
   }
 
   async function pauseMonitoring() {
-    addBreadcrumb('voicemirror', 'Monitoring paused');
+    addBreadcrumb("voicemirror", "Monitoring paused");
     if (playerNodeRef.current) {
       playerNodeRef.current.onEnded = null;
       playerNodeRef.current.stop();
@@ -354,10 +401,13 @@ export function useVoiceMirror(
         try {
           await encoderService.stopEncoding();
         } catch (e) {
-          console.error('[AudioEncoder] stopEncoding failed during pause cleanup:', e);
+          console.error(
+            "[AudioEncoder] stopEncoding failed during pause cleanup:",
+            e,
+          );
           captureException(e, {
-            operation: 'AudioEncoder.stopEncoding',
-            phase: 'pause_cleanup',
+            operation: "AudioEncoder.stopEncoding",
+            phase: "pause_cleanup",
             filePath,
           });
         }
@@ -367,19 +417,19 @@ export function useVoiceMirror(
 
     await audioContextRef.current?.suspend();
     await recordingService.setAudioSessionActivity(false);
-    phaseRef.current = 'paused';
-    setPhase('paused');
+    phaseRef.current = "paused";
+    setPhase("paused");
     setLevelHistory(new Array(LEVEL_HISTORY_SIZE).fill(0));
     setCurrentDb(null);
   }
 
   async function resumeMonitoring() {
-    addBreadcrumb('voicemirror', 'Monitoring resumed');
+    addBreadcrumb("voicemirror", "Monitoring resumed");
     await startMonitoring();
   }
 
   function togglePause() {
-    if (phaseRef.current === 'paused') {
+    if (phaseRef.current === "paused") {
       void resumeMonitoring();
     } else {
       void pauseMonitoring();
@@ -387,7 +437,7 @@ export function useVoiceMirror(
   }
 
   async function suspendForListPlayback() {
-    wasUserPausedRef.current = phaseRef.current === 'paused';
+    wasUserPausedRef.current = phaseRef.current === "paused";
 
     if (playerNodeRef.current) {
       playerNodeRef.current.onEnded = null;
@@ -396,11 +446,11 @@ export function useVoiceMirror(
     }
     stopPlaybackLevels();
 
-    if (phaseRef.current !== 'paused') {
+    if (phaseRef.current !== "paused") {
       audioRecorderRef.current?.clearOnAudioReady();
       audioRecorderRef.current?.stop();
-      phaseRef.current = 'idle';
-      setPhase('idle');
+      phaseRef.current = "idle";
+      setPhase("idle");
     } else {
       await recordingService.setAudioSessionActivity(true);
     }
@@ -410,8 +460,8 @@ export function useVoiceMirror(
 
   async function resumeFromListPlayback() {
     if (wasUserPausedRef.current) {
-      phaseRef.current = 'paused';
-      setPhase('paused');
+      phaseRef.current = "paused";
+      setPhase("paused");
       await audioContextRef.current?.suspend();
       await recordingService.setAudioSessionActivity(false);
     } else {

--- a/src/lib/__tests__/audio.test.ts
+++ b/src/lib/__tests__/audio.test.ts
@@ -1,25 +1,25 @@
-import { computeNormalizedLevel, computeLevel, dbToNormalized } from '../audio';
-import { DB_FLOOR, DB_CEIL } from '../../constants/audio';
+import { computeNormalizedLevel, computeLevel, dbToNormalized } from "../audio";
+import { DB_FLOOR, DB_CEIL } from "../../constants/audio";
 
-describe('computeNormalizedLevel', () => {
-  it('returns 0 for silence (all zeros)', () => {
+describe("computeNormalizedLevel", () => {
+  it("returns 0 for silence (all zeros)", () => {
     const samples = new Float32Array(4096);
     expect(computeNormalizedLevel(samples, 0, 4096)).toBe(0);
   });
 
-  it('returns 1 for full-scale signal (all 1.0)', () => {
+  it("returns 1 for full-scale signal (all 1.0)", () => {
     const samples = new Float32Array(4096).fill(1.0);
     expect(computeNormalizedLevel(samples, 0, 4096)).toBe(1);
   });
 
-  it('returns a value between 0 and 1 for intermediate amplitude', () => {
+  it("returns a value between 0 and 1 for intermediate amplitude", () => {
     const samples = new Float32Array(4096).fill(0.01);
     const result = computeNormalizedLevel(samples, 0, 4096);
     expect(result).toBeGreaterThan(0);
     expect(result).toBeLessThan(1);
   });
 
-  it('only reads the specified slice via startFrame/numFrames', () => {
+  it("only reads the specified slice via startFrame/numFrames", () => {
     const samples = new Float32Array(8192);
     // Fill first half with silence, second half with loud signal
     for (let i = 4096; i < 8192; i++) samples[i] = 1.0;
@@ -31,45 +31,45 @@ describe('computeNormalizedLevel', () => {
     expect(loudResult).toBe(1);
   });
 
-  it('clamps values below DB_FLOOR to 0', () => {
+  it("clamps values below DB_FLOOR to 0", () => {
     // Very quiet signal well below DB_FLOOR (-70 dB)
     const samples = new Float32Array(4096).fill(1e-6);
     expect(computeNormalizedLevel(samples, 0, 4096)).toBe(0);
   });
 
-  it('clamps values above DB_CEIL to 1', () => {
+  it("clamps values above DB_CEIL to 1", () => {
     // Full scale signal is 0 dB, well above DB_CEIL (-10 dB)
     const samples = new Float32Array(4096).fill(1.0);
     expect(computeNormalizedLevel(samples, 0, 4096)).toBe(1);
   });
 });
 
-describe('computeLevel', () => {
-  it('returns both normalized and db values', () => {
+describe("computeLevel", () => {
+  it("returns both normalized and db values", () => {
     const samples = new Float32Array(4096).fill(0.01);
     const result = computeLevel(samples, 0, 4096);
-    expect(result).toHaveProperty('normalized');
-    expect(result).toHaveProperty('db');
+    expect(result).toHaveProperty("normalized");
+    expect(result).toHaveProperty("db");
     expect(result.normalized).toBeGreaterThan(0);
     expect(result.normalized).toBeLessThan(1);
     expect(result.db).toBeCloseTo(-40, 0);
   });
 
-  it('returns 0 dB for full-scale signal', () => {
+  it("returns 0 dB for full-scale signal", () => {
     const samples = new Float32Array(4096).fill(1.0);
     const result = computeLevel(samples, 0, 4096);
     expect(result.normalized).toBe(1);
     expect(result.db).toBeCloseTo(0, 1);
   });
 
-  it('returns very low dB for silence', () => {
+  it("returns very low dB for silence", () => {
     const samples = new Float32Array(4096);
     const result = computeLevel(samples, 0, 4096);
     expect(result.normalized).toBe(0);
     expect(result.db).toBeLessThan(DB_FLOOR);
   });
 
-  it('matches computeNormalizedLevel for normalized value', () => {
+  it("matches computeNormalizedLevel for normalized value", () => {
     const samples = new Float32Array(4096).fill(0.05);
     const level = computeLevel(samples, 0, 4096);
     const normalized = computeNormalizedLevel(samples, 0, 4096);
@@ -77,24 +77,24 @@ describe('computeLevel', () => {
   });
 });
 
-describe('dbToNormalized', () => {
-  it('returns 0 for values at DB_FLOOR', () => {
+describe("dbToNormalized", () => {
+  it("returns 0 for values at DB_FLOOR", () => {
     expect(dbToNormalized(DB_FLOOR)).toBe(0);
   });
 
-  it('returns 1 for values at DB_CEIL', () => {
+  it("returns 1 for values at DB_CEIL", () => {
     expect(dbToNormalized(DB_CEIL)).toBe(1);
   });
 
-  it('clamps values below DB_FLOOR to 0', () => {
+  it("clamps values below DB_FLOOR to 0", () => {
     expect(dbToNormalized(DB_FLOOR - 20)).toBe(0);
   });
 
-  it('clamps values above DB_CEIL to 1', () => {
+  it("clamps values above DB_CEIL to 1", () => {
     expect(dbToNormalized(DB_CEIL + 20)).toBe(1);
   });
 
-  it('returns mid-range value for midpoint dB', () => {
+  it("returns mid-range value for midpoint dB", () => {
     const midDb = (DB_FLOOR + DB_CEIL) / 2;
     expect(dbToNormalized(midDb)).toBeCloseTo(0.5, 5);
   });

--- a/src/lib/__tests__/recordings.test.ts
+++ b/src/lib/__tests__/recordings.test.ts
@@ -1,50 +1,65 @@
-jest.mock('../sentryHelpers', () => ({
+jest.mock("../sentryHelpers", () => ({
   captureException: jest.fn(),
   captureMessage: jest.fn(),
   addBreadcrumb: jest.fn(),
 }));
 
-import { loadRecordings, saveRecordings, newFilePath } from '../recordings';
+import { loadRecordings, saveRecordings, newFilePath } from "../recordings";
 
 const store: Record<string, string> = {};
 
-jest.mock('expo-file-system', () => {
+jest.mock("expo-file-system", () => {
   class MockFile {
     private key: string;
     constructor(parentOrUri: { uri?: string } | string, name?: string) {
-      if (typeof parentOrUri === 'string') {
-        this.key = parentOrUri.replace('file://', '');
+      if (typeof parentOrUri === "string") {
+        this.key = parentOrUri.replace("file://", "");
       } else {
-        const parentUri = (parentOrUri as { uri?: string }).uri ?? '';
-        this.key = `${parentUri.replace('file://', '')}/${name ?? ''}`;
+        const parentUri = (parentOrUri as { uri?: string }).uri ?? "";
+        this.key = `${parentUri.replace("file://", "")}/${name ?? ""}`;
       }
     }
-    get uri() { return 'file://' + this.key; }
-    get exists() { return this.key in store; }
-    async text() { return store[this.key] ?? '[]'; }
-    write(content: string) { store[this.key] = content; }
-    delete() { delete store[this.key]; }
+    get uri() {
+      return "file://" + this.key;
+    }
+    get exists() {
+      return this.key in store;
+    }
+    async text() {
+      return store[this.key] ?? "[]";
+    }
+    write(content: string) {
+      store[this.key] = content;
+    }
+    delete() {
+      delete store[this.key];
+    }
   }
 
   return {
-    Paths: { document: '/mock/documents' },
+    Paths: { document: "/mock/documents" },
     Directory: class MockDirectory {
       parent: string;
       name: string;
       constructor(parent: { uri?: string } | string, name: string) {
-        this.parent = typeof parent === 'string' ? parent : (parent as { uri?: string }).uri ?? '';
+        this.parent =
+          typeof parent === "string"
+            ? parent
+            : ((parent as { uri?: string }).uri ?? "");
         this.name = name;
       }
-      get uri() { return `file://${this.parent}/${this.name}`; }
+      get uri() {
+        return `file://${this.parent}/${this.name}`;
+      }
       get exists() {
-        return (`${this.parent}/${this.name}`) in store || true;
+        return `${this.parent}/${this.name}` in store || true;
       }
       create(_opts?: { intermediates?: boolean }) {}
       list() {
         const dirPath = `${this.parent}/${this.name}`;
         return Object.keys(store)
-          .filter(k => k.startsWith(dirPath + '/') && k.endsWith('.m4a'))
-          .map(k => new MockFile('file://' + k));
+          .filter((k) => k.startsWith(dirPath + "/") && k.endsWith(".m4a"))
+          .map((k) => new MockFile("file://" + k));
       }
     },
     File: MockFile,
@@ -52,58 +67,88 @@ jest.mock('expo-file-system', () => {
 });
 
 beforeEach(() => {
-  Object.keys(store).forEach(k => delete store[k]);
+  Object.keys(store).forEach((k) => delete store[k]);
 });
 
-describe('loadRecordings', () => {
-  it('returns empty array when index.json does not exist', async () => {
+describe("loadRecordings", () => {
+  it("returns empty array when index.json does not exist", async () => {
     const result = await loadRecordings();
     expect(result).toEqual([]);
   });
 
-  it('returns parsed recordings when index.json exists', async () => {
+  it("returns parsed recordings when index.json exists", async () => {
     const recordings = [
-      { id: '1', filePath: 'file:///a.m4a', recordedAt: '2026-01-01T00:00:00.000Z', durationMs: 1000 },
+      {
+        id: "1",
+        filePath: "file:///a.m4a",
+        recordedAt: "2026-01-01T00:00:00.000Z",
+        durationMs: 1000,
+      },
     ];
-    store['/a.m4a'] = 'audio-data';
+    store["/a.m4a"] = "audio-data";
     saveRecordings(recordings);
     const loaded = await loadRecordings();
     expect(loaded).toEqual(recordings);
   });
 });
 
-describe('saveRecordings + loadRecordings', () => {
-  it('round-trips the full recordings array', async () => {
+describe("saveRecordings + loadRecordings", () => {
+  it("round-trips the full recordings array", async () => {
     const recordings = [
-      { id: '1', filePath: 'file:///a.m4a', recordedAt: '2026-01-01T00:00:00.000Z', durationMs: 1000 },
-      { id: '2', filePath: 'file:///b.m4a', recordedAt: '2026-01-02T00:00:00.000Z', durationMs: 2000 },
+      {
+        id: "1",
+        filePath: "file:///a.m4a",
+        recordedAt: "2026-01-01T00:00:00.000Z",
+        durationMs: 1000,
+      },
+      {
+        id: "2",
+        filePath: "file:///b.m4a",
+        recordedAt: "2026-01-02T00:00:00.000Z",
+        durationMs: 2000,
+      },
     ];
-    store['/a.m4a'] = 'audio-data';
-    store['/b.m4a'] = 'audio-data';
+    store["/a.m4a"] = "audio-data";
+    store["/b.m4a"] = "audio-data";
     saveRecordings(recordings);
     const loaded = await loadRecordings();
     expect(loaded).toEqual(recordings);
   });
 });
 
-describe('loadRecordings — stale entry cleanup', () => {
-  it('filters out recordings whose files do not exist on disk', async () => {
+describe("loadRecordings — stale entry cleanup", () => {
+  it("filters out recordings whose files do not exist on disk", async () => {
     const recordings = [
-      { id: '1', filePath: 'file:///mock/documents/recordings/a.m4a', recordedAt: '2026-01-01T00:00:00.000Z', durationMs: 1000 },
-      { id: '2', filePath: 'file:///mock/documents/recordings/b.m4a', recordedAt: '2026-01-02T00:00:00.000Z', durationMs: 2000 },
+      {
+        id: "1",
+        filePath: "file:///mock/documents/recordings/a.m4a",
+        recordedAt: "2026-01-01T00:00:00.000Z",
+        durationMs: 1000,
+      },
+      {
+        id: "2",
+        filePath: "file:///mock/documents/recordings/b.m4a",
+        recordedAt: "2026-01-02T00:00:00.000Z",
+        durationMs: 2000,
+      },
     ];
     saveRecordings(recordings);
 
-    store['/mock/documents/recordings/a.m4a'] = 'audio-data';
+    store["/mock/documents/recordings/a.m4a"] = "audio-data";
 
     const loaded = await loadRecordings();
     expect(loaded).toHaveLength(1);
-    expect(loaded[0].id).toBe('1');
+    expect(loaded[0].id).toBe("1");
   });
 
-  it('persists the cleaned-up list when stale entries are found', async () => {
+  it("persists the cleaned-up list when stale entries are found", async () => {
     const recordings = [
-      { id: '1', filePath: 'file:///mock/documents/recordings/a.m4a', recordedAt: '2026-01-01T00:00:00.000Z', durationMs: 1000 },
+      {
+        id: "1",
+        filePath: "file:///mock/documents/recordings/a.m4a",
+        recordedAt: "2026-01-01T00:00:00.000Z",
+        durationMs: 1000,
+      },
     ];
     saveRecordings(recordings);
 
@@ -114,83 +159,103 @@ describe('loadRecordings — stale entry cleanup', () => {
     expect(reloaded).toHaveLength(0);
   });
 
-  it('logs a warning for each stale entry', async () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+  it("logs a warning for each stale entry", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
     const recordings = [
-      { id: '1', filePath: 'file:///mock/documents/recordings/gone.m4a', recordedAt: '2026-01-01T00:00:00.000Z', durationMs: 1000 },
+      {
+        id: "1",
+        filePath: "file:///mock/documents/recordings/gone.m4a",
+        recordedAt: "2026-01-01T00:00:00.000Z",
+        durationMs: 1000,
+      },
     ];
     saveRecordings(recordings);
 
     await loadRecordings();
 
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Removing stale entry'),
-      );
-    warnSpy.mockRestore();
-  });
-});
-
-describe('loadRecordings — orphan cleanup', () => {
-  it('deletes .m4a files in the recordings directory that are not in the index', async () => {
-    const recordings = [
-      { id: '1', filePath: 'file:///mock/documents/recordings/a.m4a', recordedAt: '2026-01-01T00:00:00.000Z', durationMs: 1000 },
-    ];
-    saveRecordings(recordings);
-    store['/mock/documents/recordings/a.m4a'] = 'audio-data';
-    store['/mock/documents/recordings/orphan.m4a'] = 'orphan-audio-data';
-
-    await loadRecordings();
-
-    expect(store['/mock/documents/recordings/a.m4a']).toBe('audio-data');
-    expect('/mock/documents/recordings/orphan.m4a' in store).toBe(false);
-  });
-
-  it('does not delete .m4a files that are referenced by the index', async () => {
-    const recordings = [
-      { id: '1', filePath: 'file:///mock/documents/recordings/a.m4a', recordedAt: '2026-01-01T00:00:00.000Z', durationMs: 1000 },
-      { id: '2', filePath: 'file:///mock/documents/recordings/b.m4a', recordedAt: '2026-01-02T00:00:00.000Z', durationMs: 2000 },
-    ];
-    saveRecordings(recordings);
-    store['/mock/documents/recordings/a.m4a'] = 'audio-data-a';
-    store['/mock/documents/recordings/b.m4a'] = 'audio-data-b';
-
-    await loadRecordings();
-
-    expect(store['/mock/documents/recordings/a.m4a']).toBe('audio-data-a');
-    expect(store['/mock/documents/recordings/b.m4a']).toBe('audio-data-b');
-  });
-
-  it('does not delete non-.m4a files in the recordings directory', async () => {
-    saveRecordings([]);
-    store['/mock/documents/recordings/notes.txt'] = 'some notes';
-
-    await loadRecordings();
-
-    expect(store['/mock/documents/recordings/notes.txt']).toBe('some notes');
-  });
-
-  it('logs a warning for each orphaned file deleted', async () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
-    saveRecordings([]);
-    store['/mock/documents/recordings/orphan.m4a'] = 'orphan-data';
-
-    await loadRecordings();
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Deleting orphaned file'),
+      expect.stringContaining("Removing stale entry"),
     );
     warnSpy.mockRestore();
   });
 });
 
-describe('newFilePath', () => {
-  it('returns a string ending in .m4a', () => {
+describe("loadRecordings — orphan cleanup", () => {
+  it("deletes .m4a files in the recordings directory that are not in the index", async () => {
+    const recordings = [
+      {
+        id: "1",
+        filePath: "file:///mock/documents/recordings/a.m4a",
+        recordedAt: "2026-01-01T00:00:00.000Z",
+        durationMs: 1000,
+      },
+    ];
+    saveRecordings(recordings);
+    store["/mock/documents/recordings/a.m4a"] = "audio-data";
+    store["/mock/documents/recordings/orphan.m4a"] = "orphan-audio-data";
+
+    await loadRecordings();
+
+    expect(store["/mock/documents/recordings/a.m4a"]).toBe("audio-data");
+    expect("/mock/documents/recordings/orphan.m4a" in store).toBe(false);
+  });
+
+  it("does not delete .m4a files that are referenced by the index", async () => {
+    const recordings = [
+      {
+        id: "1",
+        filePath: "file:///mock/documents/recordings/a.m4a",
+        recordedAt: "2026-01-01T00:00:00.000Z",
+        durationMs: 1000,
+      },
+      {
+        id: "2",
+        filePath: "file:///mock/documents/recordings/b.m4a",
+        recordedAt: "2026-01-02T00:00:00.000Z",
+        durationMs: 2000,
+      },
+    ];
+    saveRecordings(recordings);
+    store["/mock/documents/recordings/a.m4a"] = "audio-data-a";
+    store["/mock/documents/recordings/b.m4a"] = "audio-data-b";
+
+    await loadRecordings();
+
+    expect(store["/mock/documents/recordings/a.m4a"]).toBe("audio-data-a");
+    expect(store["/mock/documents/recordings/b.m4a"]).toBe("audio-data-b");
+  });
+
+  it("does not delete non-.m4a files in the recordings directory", async () => {
+    saveRecordings([]);
+    store["/mock/documents/recordings/notes.txt"] = "some notes";
+
+    await loadRecordings();
+
+    expect(store["/mock/documents/recordings/notes.txt"]).toBe("some notes");
+  });
+
+  it("logs a warning for each orphaned file deleted", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+    saveRecordings([]);
+    store["/mock/documents/recordings/orphan.m4a"] = "orphan-data";
+
+    await loadRecordings();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Deleting orphaned file"),
+    );
+    warnSpy.mockRestore();
+  });
+});
+
+describe("newFilePath", () => {
+  it("returns a string ending in .m4a", () => {
     const path = newFilePath();
     expect(path).toMatch(/\.m4a$/);
   });
 
-  it('returns unique paths on successive calls', () => {
-    jest.spyOn(Date, 'now').mockReturnValueOnce(1000).mockReturnValueOnce(2000);
+  it("returns unique paths on successive calls", () => {
+    jest.spyOn(Date, "now").mockReturnValueOnce(1000).mockReturnValueOnce(2000);
     const p1 = newFilePath();
     const p2 = newFilePath();
     expect(p1).not.toBe(p2);

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -1,4 +1,4 @@
-import { DB_FLOOR, DB_CEIL } from '../constants/audio';
+import { DB_FLOOR, DB_CEIL } from "../constants/audio";
 
 export type LevelResult = {
   normalized: number;
@@ -17,7 +17,10 @@ export function computeLevel(
   }
   const rms = Math.sqrt(sumSq / numFrames);
   const db = 20 * Math.log10(Math.max(rms, 1e-10));
-  const normalized = Math.max(0, Math.min(1, (db - DB_FLOOR) / (DB_CEIL - DB_FLOOR)));
+  const normalized = Math.max(
+    0,
+    Math.min(1, (db - DB_FLOOR) / (DB_CEIL - DB_FLOOR)),
+  );
   return { normalized, db };
 }
 

--- a/src/lib/recordings.ts
+++ b/src/lib/recordings.ts
@@ -1,5 +1,5 @@
-import { Directory, File, Paths } from 'expo-file-system';
-import { captureException, captureMessage } from './sentryHelpers';
+import { Directory, File, Paths } from "expo-file-system";
+import { captureException, captureMessage } from "./sentryHelpers";
 
 export interface Recording {
   id: string;
@@ -8,8 +8,9 @@ export interface Recording {
   durationMs: number;
 }
 
-const recordingsDir = (): Directory => new Directory(Paths.document, 'recordings');
-const indexFile = (): File => new File(recordingsDir(), 'index.json');
+const recordingsDir = (): Directory =>
+  new Directory(Paths.document, "recordings");
+const indexFile = (): File => new File(recordingsDir(), "index.json");
 
 export function ensureDir(): void {
   const dir = recordingsDir();
@@ -32,11 +33,15 @@ export async function loadRecordings(): Promise<Recording[]> {
       console.warn(
         `[recordings] Removing stale entry: ${recording.filePath} (file not found on disk)`,
       );
-      captureMessage('Stale recording entry removed (file missing)', {
-        operation: 'loadRecordings',
-        filePath: recording.filePath,
-        recordingId: recording.id,
-      }, 'warning');
+      captureMessage(
+        "Stale recording entry removed (file missing)",
+        {
+          operation: "loadRecordings",
+          filePath: recording.filePath,
+          recordingId: recording.id,
+        },
+        "warning",
+      );
     }
   }
 
@@ -45,23 +50,34 @@ export async function loadRecordings(): Promise<Recording[]> {
   }
 
   // Delete orphaned .m4a files (on disk but not in index)
-  const validUris = new Set(valid.map(r => r.filePath));
+  const validUris = new Set(valid.map((r) => r.filePath));
   const dir = recordingsDir();
   for (const entry of dir.list()) {
-    if (entry instanceof File && entry.uri.endsWith('.m4a') && !validUris.has(entry.uri)) {
+    if (
+      entry instanceof File &&
+      entry.uri.endsWith(".m4a") &&
+      !validUris.has(entry.uri)
+    ) {
       console.warn(
         `[recordings] Deleting orphaned file: ${entry.uri} (not in index)`,
       );
-      captureMessage('Orphaned recording file deleted', {
-        operation: 'loadRecordings',
-        fileUri: entry.uri,
-      }, 'warning');
+      captureMessage(
+        "Orphaned recording file deleted",
+        {
+          operation: "loadRecordings",
+          fileUri: entry.uri,
+        },
+        "warning",
+      );
       try {
         entry.delete();
       } catch (e) {
-        console.error(`[recordings] Failed to delete orphaned file: ${entry.uri}`, e);
+        console.error(
+          `[recordings] Failed to delete orphaned file: ${entry.uri}`,
+          e,
+        );
         captureException(e, {
-          operation: 'deleteOrphanedFile',
+          operation: "deleteOrphanedFile",
           fileUri: entry.uri,
         });
       }
@@ -80,5 +96,5 @@ export function newFilePath(): string {
   ensureDir();
   const dir = recordingsDir();
   const file = new File(dir, `recording_${Date.now()}.m4a`);
-  return file.uri.replace('file://', '');
+  return file.uri.replace("file://", "");
 }

--- a/src/lib/sentryHelpers.ts
+++ b/src/lib/sentryHelpers.ts
@@ -1,11 +1,11 @@
-import * as Sentry from '@sentry/react-native';
+import * as Sentry from "@sentry/react-native";
 
 export function captureException(
   error: unknown,
   context: Record<string, unknown>,
 ): void {
   Sentry.withScope((scope) => {
-    scope.setContext('operation', context);
+    scope.setContext("operation", context);
     Sentry.captureException(error);
   });
 }
@@ -13,10 +13,10 @@ export function captureException(
 export function captureMessage(
   message: string,
   context: Record<string, unknown>,
-  level: Sentry.SeverityLevel = 'error',
+  level: Sentry.SeverityLevel = "error",
 ): void {
   Sentry.withScope((scope) => {
-    scope.setContext('operation', context);
+    scope.setContext("operation", context);
     scope.setLevel(level);
     Sentry.captureMessage(message);
   });
@@ -26,7 +26,7 @@ export function addBreadcrumb(
   category: string,
   message: string,
   data?: Record<string, unknown>,
-  level: Sentry.SeverityLevel = 'info',
+  level: Sentry.SeverityLevel = "info",
 ): void {
   Sentry.addBreadcrumb({
     category,

--- a/src/repositories/RecordingsRepository.ts
+++ b/src/repositories/RecordingsRepository.ts
@@ -1,10 +1,10 @@
-import { File } from 'expo-file-system';
+import { File } from "expo-file-system";
 import {
   type Recording,
   loadRecordings,
   saveRecordings,
   newFilePath as libNewFilePath,
-} from '../lib/recordings';
+} from "../lib/recordings";
 
 export type { Recording };
 
@@ -29,7 +29,7 @@ export class RealRecordingsRepository implements IRecordingsRepository {
   }
 
   deleteFile(path: string): void {
-    const file = new File('file://' + path);
+    const file = new File("file://" + path);
     if (file.exists) file.delete();
   }
 }

--- a/src/repositories/SettingsRepository.ts
+++ b/src/repositories/SettingsRepository.ts
@@ -1,19 +1,22 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { type AppSettings, DEFAULT_SETTINGS } from '../types/settings';
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { type AppSettings, DEFAULT_SETTINGS } from "../types/settings";
 
 const STORAGE_KEYS: Record<keyof AppSettings, string> = {
-  voiceThresholdDb: 'setting:voiceThresholdDb',
-  voiceOnsetMs: 'setting:voiceOnsetMs',
-  silenceThresholdDb: 'setting:silenceThresholdDb',
-  silenceDurationMs: 'setting:silenceDurationMs',
-  minRecordingMs: 'setting:minRecordingMs',
-  maxRecordings: 'setting:maxRecordings',
-  maxRecordingMs: 'setting:maxRecordingMs',
+  voiceThresholdDb: "setting:voiceThresholdDb",
+  voiceOnsetMs: "setting:voiceOnsetMs",
+  silenceThresholdDb: "setting:silenceThresholdDb",
+  silenceDurationMs: "setting:silenceDurationMs",
+  minRecordingMs: "setting:minRecordingMs",
+  maxRecordings: "setting:maxRecordings",
+  maxRecordingMs: "setting:maxRecordingMs",
 };
 
 export interface ISettingsRepository {
   load(): Promise<AppSettings>;
-  save<K extends keyof AppSettings>(key: K, value: AppSettings[K]): Promise<void>;
+  save<K extends keyof AppSettings>(
+    key: K,
+    value: AppSettings[K],
+  ): Promise<void>;
   resetAll(): Promise<void>;
 }
 

--- a/src/services/AudioDecoderService.ts
+++ b/src/services/AudioDecoderService.ts
@@ -1,5 +1,5 @@
-import { decodeAudioData } from 'react-native-audio-api';
-import type { AudioBuffer } from 'react-native-audio-api';
+import { decodeAudioData } from "react-native-audio-api";
+import type { AudioBuffer } from "react-native-audio-api";
 
 export interface IAudioDecoderService {
   decodeAudioData(filePath: string, sampleRate: number): Promise<AudioBuffer>;

--- a/src/services/AudioEncoderService.ts
+++ b/src/services/AudioEncoderService.ts
@@ -1,4 +1,4 @@
-import AudioEncoder from 'audio-encoder';
+import AudioEncoder from "audio-encoder";
 
 export interface IAudioEncoderService {
   startEncoding(filePath: string, sampleRate: number): void;

--- a/src/services/AudioRecordingService.ts
+++ b/src/services/AudioRecordingService.ts
@@ -1,5 +1,9 @@
-import { AudioManager, AudioRecorder } from 'react-native-audio-api';
-import type { PermissionStatus, SessionOptions, AudioRecorderCallbackOptions } from 'react-native-audio-api';
+import { AudioManager, AudioRecorder } from "react-native-audio-api";
+import type {
+  PermissionStatus,
+  SessionOptions,
+  AudioRecorderCallbackOptions,
+} from "react-native-audio-api";
 
 export type AudioChunkEvent = {
   chunk: Float32Array;

--- a/src/services/E2EAudioRecordingService.ts
+++ b/src/services/E2EAudioRecordingService.ts
@@ -19,7 +19,11 @@ const E2E_BRIDGE_SAMPLE_RATE = 48000;
 
 export type E2EConnectionStatus = "disconnected" | "connecting" | "connected";
 
-function resample(input: Float32Array, fromRate: number, toRate: number): Float32Array {
+function resample(
+  input: Float32Array,
+  fromRate: number,
+  toRate: number,
+): Float32Array {
   if (fromRate === toRate) return input;
   const ratio = toRate / fromRate;
   const outLen = Math.round(input.length * ratio);
@@ -108,7 +112,11 @@ class E2EAudioRecorder implements IAudioRecorder {
         return;
       }
       const raw = new Float32Array(buffer);
-      const samples = resample(raw, E2E_BRIDGE_SAMPLE_RATE, this.targetSampleRate);
+      const samples = resample(
+        raw,
+        E2E_BRIDGE_SAMPLE_RATE,
+        this.targetSampleRate,
+      );
       this.callback({ chunk: samples, numFrames: samples.length });
     };
 


### PR DESCRIPTION
## Summary

- **Prettier setup**: Installed `prettier`, `eslint-config-prettier`, `eslint-plugin-prettier` and integrated into ESLint config via `eslint-plugin-prettier/recommended`
- **npm scripts**: Added `format` (write mode) and `format:check` (CI mode) scripts targeting `src/`, `app/`, `e2e/`, and root config files
- **Claude Code hook**: Added `PostToolUse` hook on `Edit|Write` that auto-formats the affected file via `jq` + `pnpm prettier --write`
- **CI check**: Added `Format check` step to CI workflow that fails if any files are unformatted
- **Initial formatting**: Applied Prettier to the entire codebase in this commit

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no errors, only pre-existing warnings)
- [x] `pnpm test:ci` passes (all 113 tests)
- [x] `pnpm format:check` passes
- [x] CI workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)