### PR TITLE
fix: hoist @sentry/cli for pnpm compatibility with Xcode build phases

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+public-hoist-pattern[]=@sentry/cli

--- a/package.json
+++ b/package.json
@@ -90,5 +90,10 @@
       "/node_modules/(?!(.pnpm|react-native|@react-native|@react-native-community|expo|@expo|@expo-google-fonts|react-navigation|@react-navigation|react-native-audio-api|react-native-svg))"
     ]
   },
-  "private": true
+  "private": true,
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@sentry/cli"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Hoist `@sentry/cli` to top-level `node_modules/` via `public-hoist-pattern` in `.npmrc` so Xcode build phase scripts running from `ios/` can resolve it
- Approve `@sentry/cli` build scripts via `pnpm.onlyBuiltDependencies` in `package.json`

## Test plan
- [x] Run `npx expo prebuild --platform ios && xcodebuild -workspace ios/VoiceMirror.xcworkspace -scheme VoiceMirror -configuration Release -sdk iphonesimulator -derivedDataPath ios/build CODE_SIGNING_ALLOWED=NO build` and verify it completes without sentry-cli module resolution errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)