### PR TITLE
fix: prevent segfault in copyToChannel on Android

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -35,6 +35,9 @@ Sentry.init({
   // Enable Logs
   enableLogs: true,
 
+  // Collect Android tombstones for richer native crash context
+  enableTombstone: true,
+
   // Configure Session Replay
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1,

--- a/src/hooks/useVoiceMirror.ts
+++ b/src/hooks/useVoiceMirror.ts
@@ -369,21 +369,33 @@ export function useVoiceMirror(
       onRecordingComplete(filePath, durationMs);
     }
 
-    const bufferedFrames = bufferedFramesRef.current;
+    // Snapshot chunks and compute actual size to avoid any mismatch between
+    // bufferedFramesRef and real chunk data (native copyToChannel has no bounds
+    // checking and will segfault on overflow).
+    const chunks = chunksRef.current;
+    const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
+    if (totalLength === 0) {
+      await startMonitoring();
+      return;
+    }
+    const merged = new Float32Array(totalLength);
+    let pos = 0;
+    for (const chunk of chunks) {
+      merged.set(chunk, pos);
+      pos += chunk.length;
+    }
     const audioBuffer = context.createBuffer(
       1,
-      bufferedFrames,
+      totalLength,
       context.sampleRate,
     );
-    let offset = 0;
-    for (const chunk of chunksRef.current) {
-      audioBuffer.copyToChannel(chunk, 0, offset);
-      offset += chunk.length;
-    }
+    audioBuffer.copyToChannel(merged, 0, 0);
 
-    const bufferStartFrame = totalFramesRef.current - bufferedFramesRef.current;
-    const voiceStartSecs =
-      (voiceStartFrameRef.current - bufferStartFrame) / context.sampleRate;
+    const bufferStartFrame = totalFramesRef.current - totalLength;
+    const voiceStartSecs = Math.max(
+      0,
+      (voiceStartFrameRef.current - bufferStartFrame) / context.sampleRate,
+    );
 
     const playerNode = context.createBufferSource();
     playerNodeRef.current = playerNode;


### PR DESCRIPTION
## Summary
- Fix SIGSEGV crash in `AudioBufferHostObject::copyToChannel` on Android by computing buffer size from actual chunk data (not `bufferedFramesRef`) and merging all chunks into a single `Float32Array` before a single `copyToChannel` call — eliminates the offset-tracking loop where a size mismatch could cause an out-of-bounds native `memcpy`
- Clamp `voiceStartSecs` to non-negative to prevent invalid playback offsets if frame accounting drifts
- Enable Sentry `enableTombstone` for richer Android NDK crash reports with thread info and better stack traces

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new warnings)
- [x] `pnpm test:ci` passes (114 tests)
- [x] Manual test on Android: record → playback cycle 3+ times without crash
- [ ] Verify Sentry now collects tombstone data on Android crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)