### PR TITLE
Fix delete action not filling full row height on swipe

### DIFF
--- a/src/components/RecordingItem.tsx
+++ b/src/components/RecordingItem.tsx
@@ -236,6 +236,7 @@ const styles = StyleSheet.create({
   },
   deleteAction: {
     width: ACTION_WIDTH,
+    height: "100%",
     backgroundColor: colors.danger,
     justifyContent: "center",
     alignItems: "center",


### PR DESCRIPTION
## Summary
- Added `height: "100%"` to the delete action style so the red delete background fills the entire row height when swiping a recording item

## Test plan
- [x] Swipe a recording item to reveal the delete action
- [x] Verify the red delete background extends to the full height of the row with no gap at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)