### PR TITLE
Allow Android emulator for E2E tests

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,5 @@
 E2E_IOS_DEVICE_NAME=iPhone 17 Pro
 E2E_IOS_PLATFORM_VERSION=26.3
-# Host machine's LAN IP for Android real device E2E tests.
-# Find it with: ipconfig getifaddr en0 (macOS)
-E2E_WS_HOST=192.168.1.42
 # Android device serial (from `adb devices`). Optional if only one device is connected.
 E2E_ANDROID_UDID=
+E2E_ANDROID_AVD=

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ E2E_IOS_DEVICE_NAME=iPhone 17 Pro
 E2E_IOS_PLATFORM_VERSION=26.3
 # Host machine's LAN IP for Android real device E2E tests.
 # Find it with: ipconfig getifaddr en0 (macOS)
-E2E_WS_HOST=192.168.1.42
+# E2E_WS_HOST=192.168.1.42
 # Android device serial (from `adb devices`). Optional if only one device is connected.
 E2E_ANDROID_UDID=
+E2E_ANDROID_AVD=

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ pnpm run build:e2e:ios:local       # → artifacts/VoiceRepeat.app
 
 #### Android (real device)
 
-Set `E2E_WS_HOST` to your machine's LAN IP before building. This IP is baked into the APK so the app can connect back to the test runner's WebSocket bridge over the network.
+Set `EXPO_PUBLIC_E2E_WS_HOST` to your machine's LAN IP before building. This IP is baked into the APK so the app can connect back to the test runner's WebSocket bridge over the network.
 
 ```sh
 # Find your LAN IP (macOS):
@@ -81,8 +81,6 @@ export E2E_WS_HOST=192.168.1.42
 
 pnpm run build:e2e:android:local   # → artifacts/VoiceRepeat.apk
 ```
-
-The build will fail with a clear error if `E2E_WS_HOST` is not set.
 
 #### EAS (cloud)
 

--- a/e2e/wdio.android.conf.ts
+++ b/e2e/wdio.android.conf.ts
@@ -13,11 +13,17 @@ export const config: WdioConfig = {
       platformName: "Android",
       "appium:automationName": "UiAutomator2",
       "appium:app": path.resolve(__dirname, "../artifacts/VoiceRepeat.apk"),
-      "appium:udid": process.env.E2E_ANDROID_UDID,
       "appium:autoGrantPermissions": true,
       "appium:uiautomator2ServerInstallTimeout": 60_000,
       "appium:uiautomator2ServerLaunchTimeout": 60_000,
       "appium:noReset": false,
+      ...(process.env.E2E_ANDROID_UDID
+        ? {
+            "appium:udid": process.env.E2E_ANDROID_UDID,
+          }
+        : {
+            "appium:avd": process.env.E2E_ANDROID_AVD,
+          }),
     },
   ],
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:e2e:ios": "npx eas-cli@latest build --profile e2e --platform ios",
     "build:e2e:android": "npx eas-cli@latest build --profile e2e --platform android",
     "build:e2e:ios:local": "export EXPO_PUBLIC_E2E=1 && npx expo prebuild --platform ios && xcodebuild -workspace ios/VoiceRepeat.xcworkspace -scheme VoiceRepeat -configuration Release -sdk iphonesimulator -derivedDataPath ios/build CODE_SIGNING_ALLOWED=NO build && mkdir -p artifacts && rm -rf artifacts/VoiceRepeat.app && cp -r ios/build/Build/Products/Release-iphonesimulator/VoiceRepeat.app artifacts/VoiceRepeat.app",
-    "build:e2e:android:local": "export EXPO_PUBLIC_E2E=1 && export EXPO_PUBLIC_E2E_WS_HOST=${E2E_WS_HOST:?\"Set E2E_WS_HOST to your machine's LAN IP (e.g. 192.168.1.42)\"} && npx expo prebuild --platform android && (cd android && ./gradlew assembleRelease) && mkdir -p artifacts && cp android/app/build/outputs/apk/release/app-release*.apk artifacts/VoiceRepeat.apk",
+    "build:e2e:android:local": "export EXPO_PUBLIC_E2E=1 && npx expo prebuild --platform android && (cd android && ./gradlew assembleRelease) && mkdir -p artifacts && cp android/app/build/outputs/apk/release/app-release*.apk artifacts/VoiceRepeat.apk",
     "e2e:ios": "wdio run e2e/wdio.ios.conf.ts",
     "e2e:android": "wdio run e2e/wdio.android.conf.ts",
     "test": "jest --watchAll",


### PR DESCRIPTION
## Summary
- Support running Android E2E tests on emulator via `E2E_ANDROID_AVD` env var, in addition to real devices via `E2E_ANDROID_UDID`
- Remove mandatory `E2E_WS_HOST` requirement from Android build script since emulators can use localhost
- Conditionally set `appium:udid` or `appium:avd` in wdio config based on which env var is provided

## Test plan
- [x] Run `pnpm e2e:android` with `E2E_ANDROID_AVD` set to an emulator name
- [ ] Run `pnpm e2e:android` with `E2E_ANDROID_UDID` set to a real device serial
- [x] Run `pnpm run build:e2e:android:local` without `E2E_WS_HOST` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)